### PR TITLE
feat(wallet): add confidential asset support for sweep CLI and RPC

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -313,9 +313,18 @@ namespace
     return true;
   }
 
-  bool parse_asset_prefixed_address_arg(const std::string& raw, crypto::asset_id& asset_id, std::string& address)
+  enum class asset_prefixed_address_mode
+  {
+    plain_address,
+    native_prefixed_address,
+    asset_prefixed_address,
+  };
+
+  bool parse_asset_prefixed_address_arg(const std::string& raw, crypto::asset_id& asset_id, std::string& address, asset_prefixed_address_mode* mode = nullptr)
   {
     address = raw;
+    if (mode)
+      *mode = asset_prefixed_address_mode::plain_address;
 
     const size_t sep = raw.find(':');
     if (sep == std::string::npos)
@@ -323,6 +332,14 @@ namespace
 
     const std::string asset_hex = raw.substr(0, sep);
     std::string parsed_address = raw.substr(sep + 1);
+    if (asset_hex == "bdx" && !parsed_address.empty())
+    {
+      asset_id = crypto::null_aid;
+      address = std::move(parsed_address);
+      if (mode)
+        *mode = asset_prefixed_address_mode::native_prefixed_address;
+      return true;
+    }
     if (asset_hex.size() != 64 || parsed_address.empty())
       return true; // not an asset-prefix format; keep legacy behavior
 
@@ -332,6 +349,8 @@ namespace
 
     asset_id = parsed_asset;
     address = std::move(parsed_address);
+    if (mode)
+      *mode = asset_prefixed_address_mode::asset_prefixed_address;
     return true;
   }
 
@@ -500,11 +519,12 @@ namespace
   const char* USAGE_PAYMENT_ID("payment_id");
   const char* USAGE_TRANSFER("transfer [index=<N1>[,<N2>,...]] [flash|unimportant] (<URI> | <assetid:address> <amount>) [subtractfeefrom=<D0>[,<D1>,all,...]] [<payment_id>]");
   const char* USAGE_LOCKED_TRANSFER("locked_transfer [index=<N1>[,<N2>,...]] [<priority>] (<URI> | <addr> <amount>) <lockblocks> [<payment_id (obsolete)>]");
-  const char* USAGE_LOCKED_SWEEP_ALL("locked_sweep_all [index=<N1>[,<N2>,...] | index=all] [<priority>] [<address>] <lockblocks> [<payment_id (obsolete)>]");
-  const char* USAGE_SWEEP_ALL("sweep_all [index=<N1>[,<N2>,...] | index=all] [flash|unimportant] [outputs=<N>] [<address> [<payment_id (obsolete)>]]");
-  const char* USAGE_SWEEP_BELOW("sweep_below <amount_threshold> [index=<N1>[,<N2>,...]] [flash|unimportant] [<address> [<payment_id (obsolete)>]]");
-  const char* USAGE_SWEEP_SINGLE("sweep_single [flash|unimportant] [outputs=<N>] <key_image> <address> [<payment_id (obsolete)>]");
-  const char* USAGE_SWEEP_ACCOUNT("sweep_account <account> [index=<N1>[,<N2>,...] | index=all] [<priority>] [<ring_size>] [outputs=<N>] <address> [<payment_id (obsolete)>]");
+  const char* USAGE_LOCKED_SWEEP_ALL("locked_sweep_all [index=<N1>[,<N2>,...] | index=all] [<priority>] [<address|bdx:address|asset_id:address>] <lockblocks> [<payment_id (obsolete)>]");
+  const char* USAGE_SWEEP_ALL("sweep_all [index=<N1>[,<N2>,...] | index=all] [flash|unimportant] [outputs=<N>] [<address|bdx:address|asset_id:address> [<payment_id (obsolete)>]]");
+  const char* USAGE_SWEEP_BELOW("sweep_below <amount_threshold> [index=<N1>[,<N2>,...]] [flash|unimportant] [<address|bdx:address|asset_id:address> [<payment_id (obsolete)>]]");
+  const char* USAGE_SWEEP_SINGLE("sweep_single [flash|unimportant] [outputs=<N>] <key_image> <address|bdx:address|asset_id:address> [<payment_id (obsolete)>]");
+  const char* USAGE_SWEEP_UNMIXABLE("sweep_unmixable [<asset_id>]");
+  const char* USAGE_SWEEP_ACCOUNT("sweep_account <account> [index=<N1>[,<N2>,...] | index=all] [<priority>] [<ring_size>] [outputs=<N>] <address|bdx:address|asset_id:address> [<payment_id (obsolete)>]");
   const char* USAGE_SIGN_TRANSFER("sign_transfer [export_raw]");
   const char* USAGE_SET_LOG("set_log <level>|{+,-,}<categories>");
   const char* USAGE_ACCOUNT("account\n"
@@ -3009,13 +3029,13 @@ simple_wallet::simple_wallet()
                            tr("Send all unlocked balance to an address and lock it for <lockblocks> (max. 1000000). If no address is specified the address of the currently selected account will be used. If the parameter \"index<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. <priority> is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used."));
   m_cmd_binder.set_handler("sweep_unmixable",
                            [this](const auto& x) { return sweep_unmixable(x); },
-                           tr("Deprecated"));
+                           tr(USAGE_SWEEP_UNMIXABLE));
   m_cmd_binder.set_handler("sweep_all", [this](const auto& x) { return sweep_all(x); },
                            tr(USAGE_SWEEP_ALL),
-                           tr("Send all unlocked balance to an address.If no address is specified the address of the currently selected account will be used. If the parameter \"index<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter \"outputs=<N>\" is specified and  N > 0, wallet splits the transaction into N even outputs."));
+                           tr("Send all unlocked balance to an address.If no address is specified the address of the currently selected account will be used. If the parameter \"index<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter \"outputs=<N>\" is specified and  N > 0, wallet splits the transaction into N even outputs. Use a plain address to sweep native balance and all assets, \"bdx:address\" to sweep only native balance, or \"asset_id:address\" to sweep only a specific asset."));
   m_cmd_binder.set_handler("sweep_account", [this](const auto& x) { return sweep_account(x); },
                            tr(USAGE_SWEEP_ACCOUNT),
-                           tr("Send all unlocked balance from a given account to an address. If the parameter \"index=<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those or all address indices, respectively. If omitted, the wallet randomly chooses an address index to be used. If the parameter \"outputs=<N>\" is specified and  N > 0, wallet splits the transaction into N even outputs."));
+                           tr("Send all unlocked balance from a given account to an address. If the parameter \"index=<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those or all address indices, respectively. If omitted, the wallet randomly chooses an address index to be used. If the parameter \"outputs=<N>\" is specified and  N > 0, wallet splits the transaction into N even outputs. Use a plain address to sweep native balance and all assets from that account, \"bdx:address\" to sweep only native balance, or \"asset_id:address\" to sweep only a specific asset from that account."));
   m_cmd_binder.set_handler("sweep_below",
                            [this](const auto& x) { return sweep_below(x); },
                            tr(USAGE_SWEEP_BELOW),
@@ -3026,7 +3046,7 @@ simple_wallet::simple_wallet()
                            tr("Send a single output of the given key image to an address without change."));
   m_cmd_binder.set_handler("sweep_unmixable",
                            [this](const auto& x) { return sweep_unmixable(x); },
-                           tr("Deprecated"));
+                           tr(USAGE_SWEEP_UNMIXABLE));
   m_cmd_binder.set_handler("sign_transfer",
                            [this](const auto& x) { return sign_transfer(x); },
                            tr(USAGE_SIGN_TRANSFER),
@@ -8606,12 +8626,29 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
   if (!try_connect_to_daemon())
     return true;
 
+  std::optional<crypto::asset_id> requested_asset_id;
+  if (args_.size() > 1)
+  {
+    PRINT_USAGE(USAGE_SWEEP_UNMIXABLE);
+    return true;
+  }
+  if (!args_.empty())
+  {
+    crypto::asset_id parsed_asset_id = crypto::null_aid;
+    if (args_[0].size() != 64 || !tools::hex_to_type(args_[0], parsed_asset_id))
+    {
+      fail_msg_writer() << tr("Invalid asset id");
+      return true;
+    }
+    requested_asset_id = parsed_asset_id;
+  }
+
   SCOPED_WALLET_UNLOCK();
 
   try
   {
     // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_unmixable_sweep_transactions();
+    auto ptx_vector = m_wallet->create_unmixable_sweep_transactions(requested_asset_id);
 
     if (ptx_vector.empty())
     {
@@ -8624,8 +8661,21 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
     for (size_t n = 0; n < ptx_vector.size(); ++n)
     {
       total_fee += ptx_vector[n].fee;
+      std::optional<crypto::asset_id> swept_asset_id;
+      for (const auto &dt: ptx_vector[n].dests)
+      {
+        if (dt.asset_id != crypto::null_aid)
+        {
+          swept_asset_id = dt.asset_id;
+          break;
+        }
+      }
       for (auto i: ptx_vector[n].selected_transfers)
-        total_unmixable += m_wallet->get_transfer_details(i).amount();
+      {
+        const auto& td = m_wallet->get_transfer_details(i);
+        if (!swept_asset_id || td.get_asset_id() == *swept_asset_id)
+          total_unmixable += td.amount();
+      }
     }
 
     std::string prompt_str = tr("Sweeping ") + print_money(total_unmixable);
@@ -8695,6 +8745,12 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::sweep_main_internal(sweep_type_t sweep_type, std::vector<tools::wallet2::pending_tx> &ptx_vector, cryptonote::address_parse_info const &dest, bool flash)
 {
+  if (ptx_vector.empty())
+  {
+    fail_msg_writer() << tr("No outputs found, or daemon is not ready");
+    return false;
+  }
+
   if ((sweep_type == sweep_type_t::stake || sweep_type == sweep_type_t::register_stake) && ptx_vector.size() > 1)
   {
     fail_msg_writer() << tr("Too many outputs. Please sweep_all first");
@@ -8709,17 +8765,23 @@ bool simple_wallet::sweep_main_internal(sweep_type_t sweep_type, std::vector<too
       return true;
     }
 
-    if (ptx_vector[0].selected_transfers.size() != 1)
+    size_t asset_input_count = 0;
+    for (auto i: ptx_vector[0].selected_transfers)
+      asset_input_count += m_wallet->get_transfer_details(i).get_asset_id() != crypto::null_aid;
+
+    if (asset_input_count > 0)
+    {
+      if (asset_input_count != 1)
+      {
+        fail_msg_writer() << tr("The transaction uses multiple or no asset inputs, which is not supposed to happen");
+        return true;
+      }
+    }
+    else if (ptx_vector[0].selected_transfers.size() != 1)
     {
       fail_msg_writer() << tr("The transaction uses multiple or no inputs, which is not supposed to happen");
       return true;
     }
-  }
-
-  if (ptx_vector.empty())
-  {
-    fail_msg_writer() << tr("No outputs found, or daemon is not ready");
-    return false;
   }
 
   // give user total and fee, and prompt to confirm
@@ -8727,8 +8789,22 @@ bool simple_wallet::sweep_main_internal(sweep_type_t sweep_type, std::vector<too
   for (size_t n = 0; n < ptx_vector.size(); ++n)
   {
     total_fee += ptx_vector[n].fee;
+    std::optional<crypto::asset_id> swept_asset_id;
+    for (const auto &dt: ptx_vector[n].dests)
+    {
+      if (dt.asset_id != crypto::null_aid)
+      {
+        swept_asset_id = dt.asset_id;
+        break;
+      }
+    }
+
     for (auto i: ptx_vector[n].selected_transfers)
-      total_sent += m_wallet->get_transfer_details(i).amount();
+    {
+      const auto& td = m_wallet->get_transfer_details(i);
+      if (!swept_asset_id || td.get_asset_id() == *swept_asset_id)
+        total_sent += td.amount();
+    }
 
     if (sweep_type == sweep_type_t::stake || sweep_type == sweep_type_t::register_stake)
       total_sent -= ptx_vector[n].change_dts.amount + ptx_vector[n].fee;
@@ -8840,7 +8916,7 @@ bool simple_wallet::sweep_main_internal(sweep_type_t sweep_type, std::vector<too
   return true;
 }
 
-bool simple_wallet::sweep_main(uint32_t account, uint64_t below, Transfer transfer_type, const std::vector<std::string> &args_)
+bool simple_wallet::sweep_main(uint32_t account, uint64_t below, Transfer transfer_type, const std::vector<std::string> &args_, bool plain_address_sweeps_all_assets)
 {
   auto print_usage = [this, account, below]()
   {
@@ -8953,14 +9029,27 @@ bool simple_wallet::sweep_main(uint32_t account, uint64_t below, Transfer transf
     }
   }
 
-  cryptonote::address_parse_info info;
   std::string addr;
+  std::optional<crypto::asset_id> requested_asset_id;
+  asset_prefixed_address_mode address_mode = asset_prefixed_address_mode::plain_address;
   if (local_args.size() > 0)
     addr = local_args[0];
   else
     addr = m_wallet->get_subaddress_as_str({m_current_subaddress_account, 0});
 
-  if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), addr))
+  std::string parsed_address;
+  crypto::asset_id parsed_asset_id = crypto::null_aid;
+  if (!parse_asset_prefixed_address_arg(addr, parsed_asset_id, parsed_address, &address_mode))
+  {
+    fail_msg_writer() << tr("failed to parse asset id in address");
+    print_usage();
+    return true;
+  }
+  if (parsed_asset_id != crypto::null_aid)
+    requested_asset_id = parsed_asset_id;
+
+  cryptonote::address_parse_info info;
+  if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), parsed_address))
   {
     fail_msg_writer() << tr("failed to parse address");
     print_usage();
@@ -8982,7 +9071,11 @@ bool simple_wallet::sweep_main(uint32_t account, uint64_t below, Transfer transf
   SCOPED_WALLET_UNLOCK();
   try
   {
-    auto ptx_vector = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, cryptonote::TX_OUTPUT_DECOYS, unlock_block /* unlock_time */, priority, extra, account, subaddr_indices);
+    const auto selection_mode =
+        plain_address_sweeps_all_assets && address_mode == asset_prefixed_address_mode::plain_address
+            ? tools::wallet2::sweep_selection_mode::native_and_all_assets
+            : tools::wallet2::sweep_selection_mode::native_only;
+    auto ptx_vector = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, cryptonote::TX_OUTPUT_DECOYS, unlock_block /* unlock_time */, priority, extra, account, subaddr_indices, requested_asset_id, cryptonote::txtype::standard, selection_mode);
     sweep_main_internal(sweep_type_t::all_or_below, ptx_vector, info, priority == tools::tx_priority_flash);
   }
   catch (const std::exception &e)
@@ -9013,7 +9106,7 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
   {
     priority = m_wallet->get_default_priority();
     if (priority == 0)
-      priority = tools::tx_priority_flash;
+      priority = tools::tx_priority_unimportant;
   }
 
   size_t outputs = 1;
@@ -9055,8 +9148,19 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
     return true;
   }
 
+  std::string parsed_address;
+  std::optional<crypto::asset_id> requested_asset_id;
+  crypto::asset_id parsed_asset_id = crypto::null_aid;
+  if (!parse_asset_prefixed_address_arg(local_args[1], parsed_asset_id, parsed_address))
+  {
+    fail_msg_writer() << tr("failed to parse asset id in address");
+    return true;
+  }
+  if (parsed_asset_id != crypto::null_aid)
+    requested_asset_id = parsed_asset_id;
+
   cryptonote::address_parse_info info;
-  if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), local_args[1]))
+  if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), parsed_address))
   {
     fail_msg_writer() << tr("failed to parse address");
     return true;
@@ -9078,7 +9182,7 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
   try
   {
     // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_transactions_single(ki, info.address, info.is_subaddress, outputs, cryptonote::TX_OUTPUT_DECOYS, 0 /* unlock_time */, priority, extra);
+    auto ptx_vector = m_wallet->create_transactions_single(ki, info.address, info.is_subaddress, outputs, cryptonote::TX_OUTPUT_DECOYS, 0 /* unlock_time */, priority, extra, requested_asset_id);
     sweep_main_internal(sweep_type_t::single, ptx_vector, info, priority == tools::tx_priority_flash);
   }
   catch (const std::exception& e)
@@ -9096,7 +9200,7 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::sweep_all(const std::vector<std::string> &args_)
 {
-  return sweep_main(m_current_subaddress_account, 0, Transfer::Normal, args_);
+  return sweep_main(m_current_subaddress_account, 0, Transfer::Normal, args_, true);
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::sweep_account(const std::vector<std::string> &args_)
@@ -9115,7 +9219,7 @@ bool simple_wallet::sweep_account(const std::vector<std::string> &args_)
   }
   local_args.erase(local_args.begin());
 
-  sweep_main(account, 0, Transfer::Normal, local_args);
+  sweep_main(account, 0, Transfer::Normal, local_args, true);
   return true;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -200,7 +200,7 @@ namespace cryptonote
 
     enum class sweep_type_t { stake, register_stake, all_or_below, single };
     bool sweep_main_internal(sweep_type_t sweep_type, std::vector<tools::wallet2::pending_tx> &ptx_vector, cryptonote::address_parse_info const &dest, bool flash);
-    bool sweep_main(uint32_t account, uint64_t below, Transfer transfer_type, const std::vector<std::string> &args);
+    bool sweep_main(uint32_t account, uint64_t below, Transfer transfer_type, const std::vector<std::string> &args, bool plain_address_sweeps_all_assets = false);
     bool sweep_all(const std::vector<std::string> &args);
     bool sweep_account(const std::vector<std::string> &args);
     bool sweep_below(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10559,7 +10559,6 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
   rct::multisig_out msout;
   LOG_PRINT_L2("constructing tx for " << sources.size() << " sources and " << splitted_dsts.size() << " destinations");
   auto sources_copy = sources;
-  std::cout<<"construct_tx_and_get_tx_key"<<std::endl;
   bool r = cryptonote::construct_tx_and_get_tx_key(
       m_account.get_keys(),
       m_subaddresses,
@@ -12410,7 +12409,6 @@ skip_tx:
     const auto tx_dsts = tx.get_adjusted_dsts(tx.needed_fee);
     cryptonote::transaction test_tx;
     pending_tx test_ptx;
-    std::cout<<"transfer_selected_rct"<<std::endl;
     // 3rd time
     transfer_selected_rct(  tx_dsts,                    /* NOMOD std::vector<cryptonote::tx_destination_entry> dsts,*/
                             tx.selected_transfers,      /* const std::list<size_t> selected_transfers */
@@ -12533,13 +12531,163 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, s
   return true;
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, cryptonote::txtype tx_type)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, std::optional<crypto::asset_id> requested_asset_id, cryptonote::txtype tx_type, sweep_selection_mode selection_mode)
 {
   std::vector<size_t> unused_transfers_indices;
   std::vector<size_t> unused_dust_indices;
+  std::vector<size_t> preselected_asset_inputs;
 
   THROW_WALLET_EXCEPTION_IF(unlocked_balance(subaddr_account, false,NULL,NULL) == 0, error::wallet_internal_error, "No unlocked balance in the entire wallet");
 
+  if (requested_asset_id)
+  {
+    std::map<uint32_t, std::vector<size_t>> asset_indices_per_subaddr;
+    std::map<uint32_t, std::pair<std::vector<size_t>, std::vector<size_t>>> native_fee_indices_per_subaddr;
+    bool fund_found = false;
+    for (size_t i = 0; i < m_transfers.size(); ++i)
+    {
+      const transfer_details& td = m_transfers[i];
+      if (!is_spent(td, false) && !td.m_frozen && !td.m_key_image_partial && is_transfer_unlocked(td) &&
+          td.m_subaddr_index.major == subaddr_account &&
+          (subaddr_indices.empty() || subaddr_indices.count(td.m_subaddr_index.minor) == 1))
+      {
+        fund_found = true;
+        if (td.m_tx.version > txversion::v1)
+        {
+          if (td.m_asset_id == *requested_asset_id && td.is_rct())
+          {
+            if (below == 0 || td.amount() < below)
+              asset_indices_per_subaddr[td.m_subaddr_index.minor].push_back(i);
+          }
+          else if (td.m_asset_id == crypto::null_aid)
+          {
+            if (td.is_rct())
+              native_fee_indices_per_subaddr[td.m_subaddr_index.minor].first.push_back(i);
+            else
+              native_fee_indices_per_subaddr[td.m_subaddr_index.minor].second.push_back(i);
+          }
+        }
+      }
+    }
+
+    THROW_WALLET_EXCEPTION_IF(!fund_found, error::wallet_internal_error, "No unlocked balance in the specified subaddress(es)");
+    THROW_WALLET_EXCEPTION_IF(asset_indices_per_subaddr.empty(), error::wallet_internal_error, "The smallest amount found is not below the specified threshold");
+
+    if (subaddr_indices.empty())
+    {
+      if (asset_indices_per_subaddr.count(0) == 1 && asset_indices_per_subaddr.size() > 1)
+        asset_indices_per_subaddr.erase(0);
+      auto i = asset_indices_per_subaddr.begin();
+      std::advance(i, crypto::rand_idx(asset_indices_per_subaddr.size()));
+      preselected_asset_inputs = i->second;
+      auto native_it = native_fee_indices_per_subaddr.find(i->first);
+      if (native_it != native_fee_indices_per_subaddr.end())
+      {
+        unused_transfers_indices = native_it->second.first;
+        unused_dust_indices = native_it->second.second;
+      }
+      LOG_PRINT_L2("Spending asset from subaddress index " << i->first);
+    }
+    else
+    {
+      for (const auto& [minor_index, asset_indices] : asset_indices_per_subaddr)
+      {
+        preselected_asset_inputs.insert(preselected_asset_inputs.end(), asset_indices.begin(), asset_indices.end());
+        const auto native_it = native_fee_indices_per_subaddr.find(minor_index);
+        if (native_it != native_fee_indices_per_subaddr.end())
+        {
+          unused_transfers_indices.insert(unused_transfers_indices.end(), native_it->second.first.begin(), native_it->second.first.end());
+          unused_dust_indices.insert(unused_dust_indices.end(), native_it->second.second.begin(), native_it->second.second.end());
+        }
+        LOG_PRINT_L2("Spending asset from subaddress index " << minor_index);
+      }
+    }
+
+    return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, unlock_time, priority, extra, requested_asset_id, tx_type, std::move(preselected_asset_inputs));
+  }
+  else if (selection_mode == sweep_selection_mode::native_and_all_assets)
+  {
+    std::map<uint32_t, std::pair<std::vector<size_t>, std::vector<size_t>>> native_indices_per_subaddr;
+    std::map<uint32_t, std::vector<size_t>> asset_indices_per_subaddr;
+
+    bool fund_found = false;
+    for (size_t i = 0; i < m_transfers.size(); ++i)
+    {
+      const transfer_details& td = m_transfers[i];
+      if (!is_spent(td, false) && !td.m_frozen && !td.m_key_image_partial && is_transfer_unlocked(td) &&
+          td.m_subaddr_index.major == subaddr_account &&
+          (subaddr_indices.empty() || subaddr_indices.count(td.m_subaddr_index.minor) == 1))
+      {
+        fund_found = true;
+        if (below != 0 && td.amount() >= below)
+          continue;
+        if (td.m_tx.version <= txversion::v1)
+          continue;
+
+        if (td.m_asset_id == crypto::null_aid)
+        {
+          if (td.is_rct())
+            native_indices_per_subaddr[td.m_subaddr_index.minor].first.push_back(i);
+          else
+            native_indices_per_subaddr[td.m_subaddr_index.minor].second.push_back(i);
+        }
+        else if (td.is_rct())
+        {
+          asset_indices_per_subaddr[td.m_subaddr_index.minor].push_back(i);
+        }
+      }
+    }
+
+    THROW_WALLET_EXCEPTION_IF(!fund_found, error::wallet_internal_error, "No unlocked balance in the specified subaddress(es)");
+    THROW_WALLET_EXCEPTION_IF(native_indices_per_subaddr.empty() && asset_indices_per_subaddr.empty(), error::wallet_internal_error, "The smallest amount found is not below the specified threshold");
+
+    if (subaddr_indices.empty())
+    {
+      std::set<uint32_t> candidate_subaddrs;
+      for (const auto& [minor_index, _] : native_indices_per_subaddr)
+        candidate_subaddrs.insert(minor_index);
+      for (const auto& [minor_index, _] : asset_indices_per_subaddr)
+        candidate_subaddrs.insert(minor_index);
+
+      if (candidate_subaddrs.count(0) == 1 && candidate_subaddrs.size() > 1)
+        candidate_subaddrs.erase(0);
+
+      auto i = candidate_subaddrs.begin();
+      std::advance(i, crypto::rand_idx(candidate_subaddrs.size()));
+      const uint32_t minor_index = *i;
+
+      const auto native_it = native_indices_per_subaddr.find(minor_index);
+      if (native_it != native_indices_per_subaddr.end())
+      {
+        unused_transfers_indices = native_it->second.first;
+        unused_dust_indices = native_it->second.second;
+      }
+
+      const auto asset_it = asset_indices_per_subaddr.find(minor_index);
+      if (asset_it != asset_indices_per_subaddr.end())
+        preselected_asset_inputs = asset_it->second;
+
+      LOG_PRINT_L2("Spending native and assets from subaddress index " << minor_index);
+    }
+    else
+    {
+      for (const auto& [minor_index, native_indices] : native_indices_per_subaddr)
+      {
+        unused_transfers_indices.insert(unused_transfers_indices.end(), native_indices.first.begin(), native_indices.first.end());
+        unused_dust_indices.insert(unused_dust_indices.end(), native_indices.second.begin(), native_indices.second.end());
+        LOG_PRINT_L2("Spending native from subaddress index " << minor_index);
+      }
+      for (const auto& [minor_index, asset_indices] : asset_indices_per_subaddr)
+      {
+        preselected_asset_inputs.insert(preselected_asset_inputs.end(), asset_indices.begin(), asset_indices.end());
+        LOG_PRINT_L2("Spending assets from subaddress index " << minor_index);
+      }
+    }
+
+    return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, unlock_time, priority, extra, requested_asset_id, tx_type, std::move(preselected_asset_inputs));
+  }
+  else
+  {
   std::map<uint32_t, std::pair<std::vector<size_t>, std::vector<size_t>>> unused_transfer_dust_indices_per_subaddr;
 
   // gather all dust and non-dust outputs of specified subaddress (if any) and below specified threshold (if any)
@@ -12555,10 +12703,13 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
         if (td.m_tx.version <= txversion::v1)
           continue;
 
-        if (td.is_rct())
-          unused_transfer_dust_indices_per_subaddr[td.m_subaddr_index.minor].first.push_back(i);
-        else
-          unused_transfer_dust_indices_per_subaddr[td.m_subaddr_index.minor].second.push_back(i);
+        if (td.m_asset_id == crypto::null_aid)
+        {
+          if (td.is_rct())
+            unused_transfer_dust_indices_per_subaddr[td.m_subaddr_index.minor].first.push_back(i);
+          else
+            unused_transfer_dust_indices_per_subaddr[td.m_subaddr_index.minor].second.push_back(i);
+        }
       }
     }
   }
@@ -12574,7 +12725,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
     std::advance(i, crypto::rand_idx(unused_transfer_dust_indices_per_subaddr.size()));
     unused_transfers_indices = i->second.first;
     unused_dust_indices = i->second.second;
-    LOG_PRINT_L2("Spending from subaddress index " << i->first);
+    LOG_PRINT_L2("Spending native from subaddress index " << i->first);
   }
   else
   {
@@ -12582,31 +12733,62 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
     {
       unused_transfers_indices.insert(unused_transfers_indices.end(), p.second.first.begin(), p.second.first.end());
       unused_dust_indices.insert(unused_dust_indices.end(), p.second.second.begin(), p.second.second.end());
-      LOG_PRINT_L2("Spending from subaddress index " << p.first);
+      LOG_PRINT_L2("Spending native from subaddress index " << p.first);
     }
   }
 
-  return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, unlock_time, priority, extra, tx_type);
+  return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, unlock_time, priority, extra, requested_asset_id, tx_type, std::move(preselected_asset_inputs));
+  }
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, cryptonote::txtype tx_type)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, std::optional<crypto::asset_id> requested_asset_id, cryptonote::txtype tx_type)
 {
   std::vector<size_t> unused_transfers_indices;
   std::vector<size_t> unused_dust_indices;
+  std::vector<size_t> preselected_asset_inputs;
+  std::optional<uint32_t> forced_subaddr_account;
   // find output with the given key image
   for (size_t i = 0; i < m_transfers.size(); ++i)
   {
     const transfer_details& td = m_transfers[i];
-    if (td.m_key_image_known && td.m_key_image == ki && !is_spent(td, false) && !td.m_frozen && is_transfer_unlocked(td))
+    const bool asset_matches =
+        requested_asset_id ? td.m_asset_id == *requested_asset_id : td.m_asset_id == crypto::null_aid;
+    if (td.m_key_image_known && td.m_key_image == ki && asset_matches &&
+        !is_spent(td, false) && !td.m_frozen && is_transfer_unlocked(td))
     {
-      if (td.is_rct())
+      if (requested_asset_id)
+      {
+        preselected_asset_inputs.push_back(i);
+        forced_subaddr_account = td.m_subaddr_index.major;
+      }
+      else if (td.is_rct())
         unused_transfers_indices.push_back(i);
       else
         unused_dust_indices.push_back(i);
       break;
     }
   }
-  return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, unlock_time, priority, extra, tx_type);
+
+  if (!preselected_asset_inputs.empty())
+  {
+    for (size_t i = 0; i < m_transfers.size(); ++i)
+    {
+      if (i == preselected_asset_inputs.front())
+        continue;
+
+      const transfer_details& td = m_transfers[i];
+      if (!is_spent(td, false) && !td.m_frozen && !td.m_key_image_partial && is_transfer_unlocked(td) &&
+          td.m_subaddr_index.major == *forced_subaddr_account && td.m_asset_id == crypto::null_aid)
+      {
+        if (td.is_rct())
+          unused_transfers_indices.push_back(i);
+        else
+          unused_dust_indices.push_back(i);
+      }
+    }
+  }
+
+  return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, unlock_time, priority, extra, requested_asset_id, tx_type, std::move(preselected_asset_inputs));
 }
 
 std::vector<wallet2::pending_tx> wallet2::create_transactions_burn(const std::vector<crypto::key_image> &ki, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra_base, cryptonote::txtype tx_type)
@@ -12823,7 +13005,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_burn(const std::ve
   return ptx_vector;
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra_base, cryptonote::txtype tx_type)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra_base, std::optional<crypto::asset_id> requested_asset_id, cryptonote::txtype tx_type, std::vector<size_t> preselected_asset_inputs)
 {
   //ensure device is let in NONE mode in any case
   hw::device &hwdev = m_account.get_device();
@@ -12846,6 +13028,10 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
   uint64_t needed_fee, available_for_fee = 0;
   uint64_t upper_transaction_weight_limit = get_upper_transaction_weight_limit();
   std::vector<std::vector<get_outs_entry>> outs;
+  const bool asset_sweep_mode = !preselected_asset_inputs.empty();
+  const bool mixed_asset_native_sweep = asset_sweep_mode && !requested_asset_id.has_value();
+  uint64_t preselected_asset_amount = 0;
+  std::unordered_map<crypto::asset_id, uint64_t> preselected_asset_amounts;
 
   auto hf_version = get_hard_fork_version();
   THROW_WALLET_EXCEPTION_IF(!hf_version, error::get_hard_fork_version_error, "Failed to query current hard fork version");
@@ -12879,7 +13065,28 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
 
   LOG_PRINT_L2("Starting with " << unused_transfers_indices.size() << " non-dust outputs and " << unused_dust_indices.size() << " dust outputs");
 
-  if (unused_dust_indices.empty() && unused_transfers_indices.empty())
+  if (asset_sweep_mode)
+  {
+    for (size_t idx : preselected_asset_inputs)
+    {
+      THROW_WALLET_EXCEPTION_IF(idx >= m_transfers.size(), error::wallet_internal_error,
+          "preselected asset input index out of range");
+      const transfer_details& td = m_transfers[idx];
+      THROW_WALLET_EXCEPTION_IF(preselected_asset_amount > std::numeric_limits<uint64_t>::max() - td.amount(),
+          error::wallet_internal_error, "asset sweep amount overflow");
+      preselected_asset_amount += td.amount();
+      THROW_WALLET_EXCEPTION_IF(td.m_asset_id == crypto::null_aid, error::wallet_internal_error,
+          "preselected asset input is native");
+      if (requested_asset_id)
+      {
+        THROW_WALLET_EXCEPTION_IF(td.m_asset_id != *requested_asset_id, error::wallet_internal_error,
+            "preselected input asset id does not match requested asset");
+      }
+      preselected_asset_amounts[td.m_asset_id] += td.amount();
+    }
+  }
+
+  if (unused_dust_indices.empty() && unused_transfers_indices.empty() && !asset_sweep_mode)
     return std::vector<wallet2::pending_tx>();
 
   // start with an empty tx
@@ -12888,40 +13095,48 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
   accumulated_outputs = 0;
   accumulated_change = 0;
   needed_fee = 0;
+  if (asset_sweep_mode)
+    txes.back().selected_transfers.insert(txes.back().selected_transfers.end(), preselected_asset_inputs.begin(), preselected_asset_inputs.end());
 
   // while we have something to send
   hwdev.set_mode(hw::device::mode::TRANSACTION_CREATE_FAKE);
-  while (!unused_dust_indices.empty() || !unused_transfers_indices.empty()) {
+  bool attempt_asset_sweep_without_native_fee_input = asset_sweep_mode && unused_dust_indices.empty() && unused_transfers_indices.empty();
+  while (attempt_asset_sweep_without_native_fee_input || !unused_dust_indices.empty() || !unused_transfers_indices.empty()) {
     TX &tx = txes.back();
+    if (attempt_asset_sweep_without_native_fee_input)
+      attempt_asset_sweep_without_native_fee_input = false;
 
     // get a random unspent output and use it to pay next chunk. We try to alternate
     // dust and non dust to ensure we never get with only dust, from which we might
     // get a tx that can't pay for itself
-    uint64_t fee_dust_threshold;
+    if (!unused_dust_indices.empty() || !unused_transfers_indices.empty())
     {
-      const uint64_t estimated_tx_weight_with_one_extra_output = estimate_tx_weight(tx.selected_transfers.size() + 1, fake_outs_count, tx.dsts.size()+1, extra.size(), clsag, bulletproof_plus);
-      fee_dust_threshold = calculate_fee_from_weight(base_fee, estimated_tx_weight_with_one_extra_output, outputs, fee_percent, fixed_fee, fee_quantization_mask);
+      uint64_t fee_dust_threshold;
+      {
+        const uint64_t estimated_tx_weight_with_one_extra_output = estimate_tx_weight(tx.selected_transfers.size() + 1, fake_outs_count, tx.dsts.size()+1, extra.size(), clsag, bulletproof_plus);
+        fee_dust_threshold = calculate_fee_from_weight(base_fee, estimated_tx_weight_with_one_extra_output, outputs, fee_percent, fixed_fee, fee_quantization_mask);
+      }
+
+      size_t idx =
+        unused_transfers_indices.empty()
+          ? pop_best_value(unused_dust_indices, tx.selected_transfers)
+        : unused_dust_indices.empty()
+          ? pop_best_value(unused_transfers_indices, tx.selected_transfers)
+        : ((tx.selected_transfers.size() & 1) || accumulated_outputs > fee_dust_threshold)
+          ? pop_best_value(unused_dust_indices, tx.selected_transfers)
+          : pop_best_value(unused_transfers_indices, tx.selected_transfers);
+
+      const transfer_details &td = m_transfers[idx];
+      LOG_PRINT_L2("Picking output " << idx << ", amount " << print_money(td.amount()));
+
+      // add this output to the list to spend
+      tx.selected_transfers.push_back(idx);
+      uint64_t available_amount = td.amount();
+      accumulated_outputs += available_amount;
+
+      // clear any fake outs we'd already gathered, since we'll need a new set
+      outs.clear();
     }
-
-    size_t idx =
-      unused_transfers_indices.empty()
-        ? pop_best_value(unused_dust_indices, tx.selected_transfers)
-      : unused_dust_indices.empty()
-        ? pop_best_value(unused_transfers_indices, tx.selected_transfers)
-      : ((tx.selected_transfers.size() & 1) || accumulated_outputs > fee_dust_threshold)
-        ? pop_best_value(unused_dust_indices, tx.selected_transfers)
-      : pop_best_value(unused_transfers_indices, tx.selected_transfers);
-
-    const transfer_details &td = m_transfers[idx];
-    LOG_PRINT_L2("Picking output " << idx << ", amount " << print_money(td.amount()));
-
-    // add this output to the list to spend
-    tx.selected_transfers.push_back(idx);
-    uint64_t available_amount = td.amount();
-    accumulated_outputs += available_amount;
-
-    // clear any fake outs we'd already gathered, since we'll need a new set
-    outs.clear();
 
     // here, check if we need to sent tx and start a new one
     LOG_PRINT_L2("Considering whether to create a tx now, " << tx.selected_transfers.size() << " inputs, tx limit "
@@ -12936,9 +13151,56 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
       const size_t num_outputs = get_num_outputs(tx.dsts, m_transfers, tx.selected_transfers, beldex_tx_params);
       needed_fee = estimate_fee(tx.selected_transfers.size(), fake_outs_count, num_outputs, extra.size(), clsag, bulletproof_plus, base_fee, fee_percent, fixed_fee, fee_quantization_mask);
 
-      // add N - 1 outputs for correct initial fee estimation
-      for (size_t i = 0; i < ((outputs > 1) ? outputs - 1 : outputs); ++i)
-        tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
+      tx.dsts.clear();
+      if (asset_sweep_mode)
+      {
+        if (mixed_asset_native_sweep)
+        {
+          for (size_t i = 0; i < ((outputs > 1) ? outputs - 1 : outputs); ++i)
+            tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
+
+          for (const auto& [asset_id, total_amount] : preselected_asset_amounts)
+          {
+            uint64_t amount_remaining = total_amount;
+            const uint64_t base_amount = total_amount / outputs;
+            const uint64_t residue = total_amount % outputs;
+            for (size_t i = 0; i < outputs; ++i)
+            {
+              tx.dsts.push_back(tx_destination_entry(0, address, is_subaddress));
+              tx.dsts.back().amount = base_amount + (i < residue ? 1 : 0);
+              tx.dsts.back().asset_id = asset_id;
+              amount_remaining -= tx.dsts.back().amount;
+            }
+            THROW_WALLET_EXCEPTION_IF(amount_remaining != 0, error::wallet_internal_error,
+                "asset sweep amount split mismatch");
+          }
+        }
+        else
+        {
+          uint64_t amount_remaining = preselected_asset_amount;
+          const uint64_t base_amount = preselected_asset_amount / outputs;
+          const uint64_t residue = preselected_asset_amount % outputs;
+          for (size_t i = 0; i < outputs; ++i)
+          {
+            tx.dsts.push_back(tx_destination_entry(0, address, is_subaddress));
+            tx.dsts.back().amount = base_amount + (i < residue ? 1 : 0);
+            tx.dsts.back().asset_id = *requested_asset_id;
+            amount_remaining -= tx.dsts.back().amount;
+          }
+          THROW_WALLET_EXCEPTION_IF(amount_remaining != 0, error::wallet_internal_error,
+              "asset sweep amount split mismatch");
+        }
+      }
+      else
+      {
+        // add N - 1 outputs for correct initial fee estimation
+        for (size_t i = 0; i < ((outputs > 1) ? outputs - 1 : outputs); ++i)
+        {
+          tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
+          if (requested_asset_id)
+            tx.dsts.back().asset_id = *requested_asset_id;
+        }
+      }
 
       LOG_PRINT_L2("Trying to create a tx now, with " << tx.dsts.size() << " destinations and " <<
         tx.selected_transfers.size() << " outputs");
@@ -12948,32 +13210,46 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
       needed_fee = calculate_fee(test_ptx.tx, txBlob.size(), base_fee, fee_percent, fixed_fee, fee_quantization_mask);
       available_for_fee = test_ptx.fee + test_ptx.change_dts.amount;
       for (auto &dt: test_ptx.dests)
-        available_for_fee += dt.amount;
+      {
+        if (!asset_sweep_mode || dt.asset_id == crypto::null_aid)
+          available_for_fee += dt.amount;
+      }
       LOG_PRINT_L2("Made a " << get_weight_string(test_ptx.tx, txBlob.size()) << " tx, with " << print_money(available_for_fee) << " available for fee (" <<
         print_money(needed_fee) << " needed)");
 
       // add last output, missed for fee estimation
-      if (outputs > 1)
+      if ((mixed_asset_native_sweep || !asset_sweep_mode) && outputs > 1)
+      {
         tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
+      }
 
       THROW_WALLET_EXCEPTION_IF(needed_fee > available_for_fee, error::wallet_internal_error, "Transaction cannot pay for itself");
 
       do {
         LOG_PRINT_L2("We made a tx, adjusting fee and saving it");
-        // distribute total transferred amount between outputs
-        uint64_t amount_transferred = available_for_fee - needed_fee;
-        uint64_t dt_amount = amount_transferred / outputs;
-        // residue is distributed as one atomic unit per output until it reaches zero
-        uint64_t residue = amount_transferred % outputs;
-        for (auto &dt: tx.dsts)
+        if (mixed_asset_native_sweep || !asset_sweep_mode)
         {
-          uint64_t dt_residue = 0;
-          if (residue > 0)
+          // distribute total transferred amount between outputs
+          uint64_t amount_transferred = available_for_fee - needed_fee;
+          uint64_t dt_amount = amount_transferred / outputs;
+          // residue is distributed as one atomic unit per output until it reaches zero
+          uint64_t residue = amount_transferred % outputs;
+          size_t native_outputs_assigned = 0;
+          for (auto &dt: tx.dsts)
           {
-            dt_residue = 1;
-            residue -= 1;
+            if (dt.asset_id != crypto::null_aid)
+              continue;
+            uint64_t dt_residue = 0;
+            if (residue > 0)
+            {
+              dt_residue = 1;
+              residue -= 1;
+            }
+            dt.amount = dt_amount + dt_residue;
+            ++native_outputs_assigned;
+            if (native_outputs_assigned == outputs)
+              break;
           }
-          dt.amount = dt_amount + dt_residue;
         }
         transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, unlock_time, needed_fee, extra,
             test_tx, test_ptx, rct_config, beldex_tx_params);
@@ -13041,11 +13317,22 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
   {
     for (size_t idx: tx.selected_transfers)
     {
-      a += m_transfers[idx].amount();
+      const auto& td = m_transfers[idx];
+      if (!asset_sweep_mode)
+        a += td.amount();
+      else if (requested_asset_id)
+      {
+        if (td.get_asset_id() == *requested_asset_id)
+          a += td.amount();
+      }
+      else if (td.get_asset_id() == crypto::null_aid)
+        a += td.amount();
     }
     a -= tx.ptx.fee;
   }
   std::vector<cryptonote::tx_destination_entry> synthetic_dsts(1, cryptonote::tx_destination_entry("", a, address, is_subaddress));
+  if (requested_asset_id)
+    synthetic_dsts.front().asset_id = *requested_asset_id;
   THROW_WALLET_EXCEPTION_IF(!sanity_check(ptx_vector, synthetic_dsts), error::wallet_internal_error, "Created transaction(s) failed sanity check");
 
   // if we made it this far, we're OK to actually send the transactions
@@ -13261,11 +13548,26 @@ const wallet2::transfer_details &wallet2::get_transfer_details(size_t idx) const
   return m_transfers[idx];
 }
 //----------------------------------------------------------------------------------------------------
-std::vector<size_t> wallet2::select_available_unmixable_outputs()
+std::vector<size_t> wallet2::select_available_unmixable_outputs(std::optional<crypto::asset_id> requested_asset_id)
 {
   // request all outputs with not enough available mixins
   constexpr size_t min_mixin = 9;
-  return select_available_outputs_from_histogram(min_mixin + 1, false, true, false);
+  if (requested_asset_id)
+  {
+    // Asset outputs are confidential and do not participate in the legacy
+    // amount-based unmixable histogram the same way native non-RCT outputs do.
+    // For asset sweep_unmixable we therefore select all unlocked outputs of the
+    // requested asset and let the no-decoy self-sweep consolidate them.
+    return select_available_outputs([&requested_asset_id](const transfer_details &td) {
+      return td.is_rct() && td.m_asset_id == *requested_asset_id;
+    });
+  }
+
+  auto outputs = select_available_outputs_from_histogram(min_mixin + 1, false, true, false);
+  outputs.erase(std::remove_if(outputs.begin(), outputs.end(),
+      [this](size_t idx) { return m_transfers[idx].m_asset_id != crypto::null_aid; }),
+      outputs.end());
+  return outputs;
 }
 //----------------------------------------------------------------------------------------------------
 std::vector<size_t> wallet2::select_available_mixable_outputs()
@@ -13275,17 +13577,35 @@ std::vector<size_t> wallet2::select_available_mixable_outputs()
   return select_available_outputs_from_histogram(min_mixin + 1, true, true, true);
 }
 //----------------------------------------------------------------------------------------------------
-std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions()
+std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions(std::optional<crypto::asset_id> requested_asset_id)
 {
   const auto base_fee  = get_base_fees();
 
   // may throw
-  std::vector<size_t> unmixable_outputs = select_available_unmixable_outputs();
+  std::vector<size_t> unmixable_outputs = select_available_unmixable_outputs(requested_asset_id);
   size_t num_dust_outputs = unmixable_outputs.size();
 
   if (num_dust_outputs == 0)
   {
     return std::vector<wallet2::pending_tx>();
+  }
+
+  if (requested_asset_id)
+  {
+    std::vector<size_t> native_fee_transfer_outputs, native_fee_dust_outputs;
+    for (size_t i = 0; i < m_transfers.size(); ++i)
+    {
+      const transfer_details& td = m_transfers[i];
+      if (td.m_asset_id != crypto::null_aid || is_spent(td, false) || td.m_frozen || td.m_key_image_partial || !is_transfer_unlocked(td) || td.m_tx.version <= txversion::v1)
+        continue;
+
+      if (td.amount() < base_fee.first)
+        native_fee_dust_outputs.push_back(i);
+      else
+        native_fee_transfer_outputs.push_back(i);
+    }
+
+    return create_transactions_from(m_account_public_address, false, 1, native_fee_transfer_outputs, native_fee_dust_outputs, cryptonote::TX_OUTPUT_DECOYS, 0 /* unlock_time */, 1 /*priority */, std::vector<uint8_t>{}, requested_asset_id, cryptonote::txtype::standard, std::move(unmixable_outputs));
   }
 
   // split in "dust" and "non dust" to make it easier to select outputs

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -808,9 +808,15 @@ private:
         uint32_t subaddr_account,
         std::set<uint32_t> subaddr_indices);
 
-    std::vector<pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, cryptonote::txtype tx_type = cryptonote::txtype::standard);
-    std::vector<pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, cryptonote::txtype tx_type = cryptonote::txtype::standard);
-    std::vector<pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, cryptonote::txtype tx_type = cryptonote::txtype::standard);
+    enum class sweep_selection_mode : uint8_t
+    {
+      native_only,
+      native_and_all_assets
+    };
+
+    std::vector<pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, std::optional<crypto::asset_id> requested_asset_id = std::nullopt, cryptonote::txtype tx_type = cryptonote::txtype::standard, sweep_selection_mode selection_mode = sweep_selection_mode::native_only);
+    std::vector<pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, std::optional<crypto::asset_id> requested_asset_id = std::nullopt, cryptonote::txtype tx_type = cryptonote::txtype::standard);
+    std::vector<pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, std::optional<crypto::asset_id> requested_asset_id = std::nullopt, cryptonote::txtype tx_type = cryptonote::txtype::standard, std::vector<size_t> preselected_asset_inputs = {});
     std::vector<pending_tx> create_transactions_burn(const std::vector<crypto::key_image> &ki, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, cryptonote::txtype tx_type = cryptonote::txtype::coin_burn);
 
     bool sanity_check(const std::vector<pending_tx> &ptx_vector, std::vector<cryptonote::tx_destination_entry> dsts, const unique_index_container& subtract_fee_from_outputs = {}) const;
@@ -824,7 +830,7 @@ private:
     bool sign_multisig_tx_from_file(const fs::path& filename, std::vector<crypto::hash> &txids, std::function<bool(const multisig_tx_set&)> accept_func);
     bool sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto::hash> &txids);
     bool sign_multisig_tx_to_file(multisig_tx_set &exported_txs, const fs::path& filename, std::vector<crypto::hash> &txids);
-    std::vector<pending_tx> create_unmixable_sweep_transactions();
+    std::vector<pending_tx> create_unmixable_sweep_transactions(std::optional<crypto::asset_id> requested_asset_id = std::nullopt);
     void discard_unmixable_outputs();
     bool check_connection(cryptonote::rpc::version_t *version = nullptr, bool *ssl = nullptr, bool throw_on_http_error = false);
     wallet::transfer_view make_transfer_view(const crypto::hash &txid, const crypto::hash &payment_id, const wallet2::payment_details &pd) const;
@@ -1145,7 +1151,7 @@ private:
     uint64_t estimate_blockchain_height();
     std::vector<size_t> select_available_outputs_from_histogram(uint64_t count, bool atleast, bool unlocked, bool allow_rct);
     std::vector<size_t> select_available_outputs(const std::function<bool(const transfer_details &td)> &f) const;
-    std::vector<size_t> select_available_unmixable_outputs();
+    std::vector<size_t> select_available_unmixable_outputs(std::optional<crypto::asset_id> requested_asset_id = std::nullopt);
     std::vector<size_t> select_available_mixable_outputs();
 
     size_t pop_best_value_from(const transfer_container &transfers, std::vector<size_t> &unused_dust_indices, const std::vector<size_t>& selected_transfers, bool smallest = false) const;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1176,32 +1176,71 @@ namespace tools
   }
 
   //------------------------------------------------------------------------------------------------------------------------------
+  enum class asset_prefixed_address_mode
+  {
+    plain_address,
+    native_prefixed_address,
+    asset_prefixed_address,
+  };
+
+  static bool parse_asset_prefixed_address(std::string_view raw, crypto::asset_id& asset_id, std::string& address, asset_prefixed_address_mode* mode = nullptr)
+  {
+    const size_t sep = raw.find(':');
+    address = std::string{raw};
+    asset_id = crypto::null_aid;
+    if (mode)
+      *mode = asset_prefixed_address_mode::plain_address;
+    if (sep == std::string_view::npos)
+      return true;
+
+    const std::string asset_hex = std::string{raw.substr(0, sep)};
+    const std::string parsed_address = std::string{raw.substr(sep + 1)};
+    if (asset_hex == "bdx" && !parsed_address.empty())
+    {
+      address = parsed_address;
+      if (mode)
+        *mode = asset_prefixed_address_mode::native_prefixed_address;
+      return true;
+    }
+    if (asset_hex.size() != 64 || parsed_address.empty())
+      return true;
+    if (!tools::hex_to_type(asset_hex, asset_id))
+      return false;
+
+    address = std::move(parsed_address);
+    if (mode)
+      *mode = asset_prefixed_address_mode::asset_prefixed_address;
+    return true;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------
   void wallet_rpc_server::validate_transfer(const std::list<wallet::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::vector<uint8_t>& extra, bool at_least_one_destination)
   {
     crypto::hash8 integrated_payment_id = crypto::null_hash8;
     std::string extra_nonce;
     for (auto it = destinations.begin(); it != destinations.end(); it++)
     {
-      cryptonote::address_parse_info info = extract_account_addr(m_wallet->nettype(), it->address);
+      crypto::asset_id parsed_asset_id = crypto::null_aid;
+      std::string parsed_address;
+      if (!parse_asset_prefixed_address(it->address, parsed_asset_id, parsed_address))
+        throw wallet_rpc_error{error_code::BAD_HEX, "Failed to parse asset_id"};
+
+      cryptonote::address_parse_info info = extract_account_addr(m_wallet->nettype(), parsed_address);
 
       cryptonote::tx_destination_entry de;
-      de.original = it->address;
+      de.original = parsed_address;
       de.addr = info.address;
       de.is_subaddress = info.is_subaddress;
       de.amount = it->amount;
       de.is_integrated = info.has_payment_id;
-
-      // HF21: confidential-asset transfer. An empty asset_id means native BDX
-      // (txout_to_key); otherwise this destination receives the named asset as
-      // a tx_out_zarcanum output. de.amount is the asset's atomic-unit amount.
-      // Mirrors the CLI's `transfer <assetid>:<address> <amount>` form
-      // (simplewallet.cpp parse_asset_prefixed_address_arg -> de.asset_id).
-      if (!it->asset_id.empty())
-      {
-        crypto::asset_id aid;
-        if (!tools::hex_to_type(it->asset_id, aid))
-          throw wallet_rpc_error{error_code::BAD_HEX, "Failed to parse asset_id in destination: " + it->asset_id};
-        de.asset_id = aid;
+      de.asset_id = parsed_asset_id;
+      if (!it->asset_id.empty()) {
+        crypto::asset_id explicit_asset_id = crypto::null_aid;
+        if (!tools::hex_to_type(it->asset_id, explicit_asset_id))
+          throw wallet_rpc_error{error_code::BAD_HEX, "Failed to parse asset_id"};
+        if (de.asset_id != crypto::null_aid && de.asset_id != explicit_asset_id)
+          throw wallet_rpc_error{error_code::BAD_HEX, "Conflicting asset ids in destination"};
+        de.asset_id = explicit_asset_id;
       }
 
       dsts.push_back(de);
@@ -1767,6 +1806,12 @@ namespace tools
     destination.back().address = req.address;
     validate_transfer(destination, req.payment_id, dsts, extra, true);
 
+    crypto::asset_id parsed_asset_id = crypto::null_aid;
+    std::string parsed_address;
+    asset_prefixed_address_mode address_mode = asset_prefixed_address_mode::plain_address;
+    if (!parse_asset_prefixed_address(req.address, parsed_asset_id, parsed_address, &address_mode))
+      throw wallet_rpc_error{error_code::BAD_HEX, "Failed to parse asset_id"};
+
     if (req.outputs < 1)
       throw wallet_rpc_error{error_code::TX_NOT_POSSIBLE, "Amount of outputs should be greater than 0."};
 
@@ -1783,7 +1828,14 @@ namespace tools
 
     {
       uint32_t priority = convert_priority(req.priority);
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, cryptonote::TX_OUTPUT_DECOYS, req.unlock_time, priority, extra, req.account_index, subaddr_indices);
+      const auto requested_asset_id = dsts[0].asset_id == crypto::null_aid
+          ? std::optional<crypto::asset_id>{}
+          : std::optional<crypto::asset_id>{dsts[0].asset_id};
+      const auto selection_mode =
+          address_mode == asset_prefixed_address_mode::plain_address && !requested_asset_id.has_value()
+              ? wallet2::sweep_selection_mode::native_and_all_assets
+              : wallet2::sweep_selection_mode::native_only;
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, cryptonote::TX_OUTPUT_DECOYS, req.unlock_time, priority, extra, req.account_index, subaddr_indices, requested_asset_id, cryptonote::txtype::standard, selection_mode);
 
       fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.amounts_by_dest_list, res.fee_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay, priority == tx_priority_flash,
             res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, res.spent_key_images_list);
@@ -1815,15 +1867,16 @@ namespace tools
 
     {
       uint32_t priority = convert_priority(req.priority);
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, req.outputs, cryptonote::TX_OUTPUT_DECOYS, req.unlock_time, priority, extra);
+      const auto requested_asset_id = dsts[0].asset_id == crypto::null_aid
+          ? std::optional<crypto::asset_id>{}
+          : std::optional<crypto::asset_id>{dsts[0].asset_id};
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, req.outputs, cryptonote::TX_OUTPUT_DECOYS, req.unlock_time, priority, extra, requested_asset_id);
 
       if (ptx_vector.empty())
         throw wallet_rpc_error{error_code::UNKNOWN_ERROR, "No outputs found"};
       if (ptx_vector.size() > 1)
         throw wallet_rpc_error{error_code::UNKNOWN_ERROR, "Multiple transactions are created, which is not supposed to happen"};
       const wallet2::pending_tx &ptx = ptx_vector[0];
-      if (ptx.selected_transfers.size() > 1)
-        throw wallet_rpc_error{error_code::UNKNOWN_ERROR, "The transaction uses multiple inputs, which is not supposed to happen"};
 
       fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.amounts_by_dest, res.fee, res.multisig_txset, res.unsigned_txset, req.do_not_relay, priority == tx_priority_flash,
           res.tx_hash, req.get_tx_hex, res.tx_blob, req.get_tx_metadata, res.tx_metadata, res.spent_key_images);


### PR DESCRIPTION

- Add asset_id:address parsing for sweep commands
- Extend sweep_all and sweep_single to support asset transfers
- Support native-only, asset-only, and native+asset sweep flows
- Propagate requested_asset_id through wallet transaction construction
- Update wallet RPC validation and transfer handling for asset destinations
- Preserve native BDX fee handling during asset sweeps