### PR TITLE
feat(ca): move ZC_sig to signatures and fix CA verification gate

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_basic.cpp
@@ -19,6 +19,7 @@ transaction::transaction(const transaction &t) :
   blob_size_valid(false),
   signatures(t.signatures),
   rct_signatures(t.rct_signatures),
+  zc_sig(t.zc_sig),
   asset_proofs(t.asset_proofs),
   pruned(t.pruned),
   unprunable_size(t.unprunable_size.load()),
@@ -40,6 +41,7 @@ transaction& transaction::operator=(const transaction& t) {
   set_blob_size_valid(false);
   signatures = t.signatures;
   rct_signatures = t.rct_signatures;
+  zc_sig = t.zc_sig;
   asset_proofs = t.asset_proofs;
   if (t.is_hash_valid()) {
     hash = t.hash;
@@ -61,6 +63,7 @@ void transaction::set_null()
   signatures.clear();
   rct_signatures = {};
   rct_signatures.type = rct::RCTType::Null;
+  zc_sig.clear();
   asset_proofs.clear();
   set_hash_valid(false);
   set_blob_size_valid(false);

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -280,10 +280,17 @@ namespace cryptonote
     std::vector<std::vector<crypto::signature>> signatures; //count signatures  always the same as inputs count
     rct::rctSig rct_signatures;
 
+    // Confidential asset input signatures (HF21+): one entry per confidential
+    // (zarcanum) input being spent, in tx.vin order. Each is a signature_v (a
+    // variant currently holding only ZC_sig), so it serializes as
+    // { "ZC_sig": {...} } inside the tx "signatures" array -- matching Zano,
+    // where ZC_sig is a signature_v rather than a proof_v. NOT in asset_proofs.
+    std::vector<rct::signature_v> zc_sig;
+
     // Confidential asset proofs (HF21+). Empty for non-asset transactions.
     // Contains: zc_asset_surjection_proof, zc_balance_proof,
     //           asset_operation_proof, asset_operation_ownership_proof,
-    //           ZC_sig (one per ZC input being spent).
+    //           zc_outs_range_proof.
     std::vector<rct::asset_proof_v> asset_proofs;
 
     // hash cache
@@ -299,6 +306,15 @@ namespace cryptonote
     bool has_zarcanum_outputs() const {
       return std::any_of(vout.begin(), vout.end(),
         [](const tx_out& o){ return std::holds_alternative<tx_out_zarcanum>(o.target); });
+    }
+
+    // Returns true if any input is a txin_zc_input (confidential asset spend).
+    // Prefix-derivable, so it decides whether the tx carries a zc_sig
+    // ("signatures") section on the wire -- for well-formed txs this equals
+    // !zc_sig.empty() (one ZC_sig per zc input).
+    bool has_zarcanum_inputs() const {
+      return std::any_of(vin.begin(), vin.end(),
+        [](const txin_v& i){ return std::holds_alternative<txin_zc_input>(i); });
     }
 
     transaction() { set_null(); }
@@ -406,7 +422,24 @@ namespace cryptonote
             rct_signatures.p.serialize_rctsig_prunable(ar, rct_signatures.type, native_inputs, native_outputs, mixin);
           }
 
-          // HF21: confidential asset proofs (present only when has_zarcanum_outputs() or for update_asset txs)
+          // HF21: confidential asset input signatures. Emitted first, under the
+          // "signatures" tag, as a signature_v vector (each a { "ZC_sig": {...} })
+          // -- keeping ZC_sig with the tx's signatures rather than lumped into
+          // the asset proofs, as Zano does. Present only when the tx spends a
+          // zarcanum input; the gate is prefix-derivable (has_zarcanum_inputs)
+          // so the deserializer knows whether to read the field, and a tx with
+          // no zc inputs (e.g. deploy_new_asset) omits it entirely rather than
+          // serializing an empty array. This gate and order must stay identical
+          // in calculate_transaction_prunable_hash or the prunable hash won't
+          // reproduce.
+          if (has_zarcanum_inputs())
+          {
+            ar.tag("signatures");
+            serialization::value(ar, zc_sig);
+          }
+
+          // HF21: confidential asset proofs (present when has_zarcanum_outputs()
+          // or for update_asset txs).
           if (!asset_proofs.empty() || has_zarcanum_outputs() || type == txtype::update_asset)
           {
             ar.tag("asset_proofs");

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1547,14 +1547,17 @@ namespace cryptonote
       try {
         const_cast<transaction&>(t).rct_signatures.p.serialize_rctsig_prunable(
                 ba, t.rct_signatures.type, native_inputs, native_outputs, mixin);
-        // HF21: asset_proofs are serialized right after rctsig_prunable in
-        // transaction::serialize_value, and both sit after unprunable_size --
-        // i.e. asset_proofs are part of the PRUNABLE region. The blob-slice path
-        // above hashes them (blob.substr(unprunable_size) covers them), so this
-        // re-serialize path must emit them too, in the same order and under the
-        // same presence condition, or the prunable hash won't match for CA txs
-        // (zc inputs/outputs and update_asset carry their proofs here, not in the
-        // native CLSAG/bulletproof arrays).
+        // HF21: the ZC input signatures (zc_sig) and asset_proofs are
+        // serialized right after rctsig_prunable in transaction::serialize_value,
+        // and both sit after unprunable_size -- i.e. they are part of the
+        // PRUNABLE region. The blob-slice path above hashes them
+        // (blob.substr(unprunable_size) covers them), so this re-serialize path
+        // must emit them too, zc_sig first then asset_proofs, under the SAME
+        // presence gates as transaction::serialize_value, or the prunable hash
+        // won't match for CA txs (zc inputs/outputs and update_asset carry their
+        // sigs/proofs here, not in the native CLSAG/bulletproof arrays).
+        if (t.has_zarcanum_inputs())
+          serialization::value(ba, const_cast<transaction&>(t).zc_sig);
         if (!t.asset_proofs.empty() || t.has_zarcanum_outputs() || t.type == txtype::update_asset)
           serialization::value(ba, const_cast<transaction&>(t).asset_proofs);
       } catch (const std::exception& e) {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3464,25 +3464,19 @@ bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_pr
   // HF21: ZC_sig.clsag_sig.I (the key image) is deliberately not serialized
   // (same reasoning as native CLSAGs' I above -- it's redundant with the
   // owning txin's own k_image field) and so deserializes to zero. Reconstruct
-  // it here, matching each ZC_sig to its zc input by relative order (the same
-  // order genZCSig's caller pushes them in, mirroring how zc_pending is
-  // indexed by final tx.vin position during construction).
+  // it here, matching each ZC_sig to its zc input by relative order (tx.zc_sig
+  // is pushed in tx.vin order during construction -- one entry per zc input).
   {
     size_t zc_sig_idx = 0;
     for (size_t n = 0; n < tx.vin.size(); ++n)
     {
       if (!std::holds_alternative<txin_zc_input>(tx.vin[n]))
         continue;
+      if (zc_sig_idx >= tx.zc_sig.size())
+        break;
       const crypto::key_image& ki = var::get<txin_zc_input>(tx.vin[n]).k_image;
-      for (size_t k = zc_sig_idx; k < tx.asset_proofs.size(); ++k)
-      {
-        if (auto* zc_sig = std::get_if<rct::ZC_sig>(&tx.asset_proofs[k]))
-        {
-          zc_sig->clsag_sig.I = rct::ki2rct(ki);
-          zc_sig_idx = k + 1;
-          break;
-        }
-      }
+      std::get<rct::ZC_sig>(tx.zc_sig[zc_sig_idx]).clsag_sig.I = rct::ki2rct(ki);
+      ++zc_sig_idx;
     }
   }
 
@@ -3841,8 +3835,25 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       return false;
     }
 
-    // HF21: verify ZC_sig / asset proofs for any confidential asset inputs.
-    if (hf_version >= feature::CONFIDENTIAL_ASSETS && !tx.asset_proofs.empty())
+    // HF21: verify ZC_sig / asset proofs for any confidential asset tx.
+    //
+    // CRITICAL: this gate must trigger on STRUCTURAL confidential-asset content
+    // (zc inputs/outputs, asset-op tx types), NOT merely on asset_proofs being
+    // non-empty. verAssetProofs is the sole place ZC_sig, surjection, balance
+    // and range proofs are verified AND the sole place their PRESENCE is
+    // enforced -- so gating it on an attacker-controlled vector would let a
+    // peer strip every proof (asset_proofs empty, tx.zc_sig empty) and skip all
+    // CA verification, forging spends / minting confidential value at will.
+    // has_zarcanum_inputs()/has_zarcanum_outputs() are prefix-derived and thus
+    // not strippable without changing the actual inputs/outputs. Covers deploy
+    // (zc outs, no zc ins), burn (zc ins, zc outs optional), emit, transfers,
+    // and update_asset (which may have neither, hence the tx-type terms).
+    const bool has_ca_content =
+        !tx.asset_proofs.empty() || !tx.zc_sig.empty() ||
+        tx.has_zarcanum_inputs() || tx.has_zarcanum_outputs() ||
+        tx.type == txtype::deploy_new_asset || tx.type == txtype::emit_asset ||
+        tx.type == txtype::burn_asset || tx.type == txtype::update_asset;
+    if (hf_version >= feature::CONFIDENTIAL_ASSETS && has_ca_content)
     {
       std::vector<rct::keyV> asset_id_rings(tx.vin.size());
       for (size_t n = 0; n < tx.vin.size(); ++n)

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1543,7 +1543,9 @@ namespace cryptonote
                                                p.spend_secret, p.amount_mask_diff, p.asset_mask_diff,
                                                p.pseudo_out_amount_commitment, p.pseudo_out_blinded_asset_id,
                                                p.real_index);
-            tx.asset_proofs.push_back(std::move(zc_sig));
+            // ZC_sig lives under the tx's signatures (tx.zc_sig), not in
+            // asset_proofs -- see transaction::zc_sig (cryptonote_basic.h).
+            tx.zc_sig.push_back(std::move(zc_sig));
           }
 
           // ── HF21: asset surjection proof (BGE) for zarcanum outputs ─────────

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1899,7 +1899,7 @@ namespace rct {
         // Zano's per-type count_type_in_variant_container prevalidation.
         {
             size_t n_surjection = 0, n_balance = 0, n_range = 0,
-                   n_asset_op = 0, n_ownership = 0, n_zc_sig = 0;
+                   n_asset_op = 0, n_ownership = 0;
             for (const auto& proof : tx.asset_proofs)
             {
                 if      (std::holds_alternative<rct::zc_asset_surjection_proof>(proof))       ++n_surjection;
@@ -1907,9 +1907,10 @@ namespace rct {
                 else if (std::holds_alternative<rct::zc_outs_range_proof>(proof))             ++n_range;
                 else if (std::holds_alternative<rct::asset_operation_proof>(proof))           ++n_asset_op;
                 else if (std::holds_alternative<rct::asset_operation_ownership_proof>(proof)) ++n_ownership;
-                else if (std::holds_alternative<rct::ZC_sig>(proof))                          ++n_zc_sig;
                 else { reason = "unknown asset proof type"; return false; }
             }
+            // ZC_sigs live under the tx's signatures (tx.zc_sig), not asset_proofs.
+            const size_t n_zc_sig = tx.zc_sig.size();
 
             // Singleton proofs: at most one of each.
             if (n_surjection > 1) { reason = "multiple zc_asset_surjection_proof entries"; return false; }
@@ -1955,17 +1956,22 @@ namespace rct {
         }
 
         // ── 1. Verify ZC_sig for each ZC input ───────────────────────────────
-        // Count ZC inputs and match them to ZC_sig entries in asset_proofs.
-        // pubkeys[i] / asset_id_rings[i] is the ring for input i (built by
-        // check_tx_inputs / check_tx_input_zc); asset_id_rings is only
-        // populated for indices where tx.vin[i] is a txin_zc_input.
+        // Count ZC inputs and match them to the tx's ZC_sig signatures (one per
+        // zc input, in tx.vin order). pubkeys[i] / asset_id_rings[i] is the ring
+        // for input i (built by check_tx_inputs / check_tx_input_zc);
+        // asset_id_rings is only populated for indices where tx.vin[i] is a
+        // txin_zc_input.
         size_t zc_sig_idx = 0;
         const key tx_prefix_hash = get_hf21_asset_proof_message(tx, pubkeys, hw::get_device("default"));
 
         std::vector<const rct::ZC_sig*> zc_sigs;
-        for (const auto& proof : tx.asset_proofs)
-            if (const auto* zs = std::get_if<rct::ZC_sig>(&proof))
-                zc_sigs.push_back(zs);
+        zc_sigs.reserve(tx.zc_sig.size());
+        for (const auto& sig : tx.zc_sig)
+        {
+            const auto* zs = std::get_if<rct::ZC_sig>(&sig);
+            if (!zs) { reason = "unknown signature type in tx.zc_sig"; return false; }
+            zc_sigs.push_back(zs);
+        }
 
         // Collect ring pubkeys for ZC inputs (subset of all inputs)
         size_t zc_input_count = 0;

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -749,6 +749,11 @@ namespace rct {
       BEGIN_SERIALIZE_OBJECT() FIELD(sig) END_SERIALIZE()
     };
 
+    // HF21: ring signature spending a single tx_out_zarcanum (confidential
+    // asset) input. Like Zano (where ZC_sig is a signature_v, not a proof_v),
+    // this is stored under the transaction's signatures (transaction::zc_sig),
+    // NOT in transaction::asset_proofs -- so it is intentionally absent from
+    // asset_proof_v below.
     struct ZC_sig
     {
       clsag_ggx clsag_sig;
@@ -781,9 +786,16 @@ namespace rct {
       zc_balance_proof,
       asset_operation_proof,
       asset_operation_ownership_proof,
-      ZC_sig,
       zc_outs_range_proof
     >;
+
+    // HF21: transaction signature variant, modeled on Zano's signature_v.
+    // Currently the only alternative is ZC_sig (confidential-asset input
+    // signatures); wrapping it in a variant makes each element serialize under
+    // its own "ZC_sig" tag inside the tx "signatures" array (transaction::zc_sig),
+    // matching Zano's `"signatures": [ { "ZC_sig": {...} } ]` shape. Add further
+    // signature kinds here as alternatives if/when needed.
+    using signature_v = std::variant<ZC_sig>;
 
 } // namespace rct (continued)
 
@@ -792,5 +804,7 @@ VARIANT_TAG(rct::zc_asset_surjection_proof,       "zc_surjection", 0xb0);
 VARIANT_TAG(rct::zc_balance_proof,                "zc_balance",    0xb1);
 VARIANT_TAG(rct::asset_operation_proof,           "asset_op_proof",0xb2);
 VARIANT_TAG(rct::asset_operation_ownership_proof, "asset_owner",   0xb3);
-VARIANT_TAG(rct::ZC_sig,                          "zc_sig",        0xb4);
+// ZC_sig is a signature_v alternative (transaction::zc_sig), not an
+// asset_proof_v member; its tag lets it serialize as { "ZC_sig": {...} }.
+VARIANT_TAG(rct::ZC_sig,                          "ZC_sig",        0xb4);
 VARIANT_TAG(rct::zc_outs_range_proof,             "zc_range_proof",0xb5);


### PR DESCRIPTION
Move the confidential-asset input signature (ZC_sig) out of transaction::asset_proofs into a dedicated transaction::zc_sig, matching Zano where ZC_sig is a signature_v rather than a proof_v. ZC_sig is now serialized as a signature_v under the "signatures" tag (rendering as { "ZC_sig": {...} }), while asset_proofs contains only the surjection, balance, range, and asset-operation proofs.

- rctTypes.h: remove ZC_sig from asset_proof_v; add signature_v = variant<ZC_sig>; tag ZC_sig as "ZC_sig".
- cryptonote_basic.{h,cpp}: add transaction::zc_sig (vector<signature_v>); serialize it (and include it in the prunable hash) only when the transaction spends zarcanum inputs, using the prefix-derived has_zarcanum_inputs() so deploy-asset transactions without ZC inputs omit the field instead of serializing an empty array.
- cryptonote_tx_utils, blockchain, and rctSigs: update transaction construction, key-image injection, and verification to consume tx.zc_sig.

SECURITY (critical): verAssetProofs is the only code path that both verifies ZC signatures, surjection, balance, and range proofs and enforces their presence. It was previously gated on !tx.asset_proofs.empty(). After moving ZC_sig out of asset_proofs, an attacker could strip all confidential-asset proofs (empty asset_proofs and empty zc_sig), causing verAssetProofs to be skipped entirely and bypassing confidential-asset verification. Gate verification instead on the transaction's structural CA content (has_zarcanum_inputs(), has_zarcanum_outputs(), and asset-operation transaction types), making proof verification mandatory whenever confidential-asset semantics are present.