### PR TITLE
Fix Zarcanum asset serialization, sweeping logic, and CLI tracking bugs

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -575,14 +575,12 @@ namespace cryptonote
   {
     account_public_address addr = {null_pkey, null_pkey};
     size_t count = 0;
-    bool found_change = false;
     for (const auto &i : destinations)
     {
       if (i.amount == 0)
         continue;
-      if (change_addr && *change_addr == i && !found_change)
+      if (change_addr && change_addr->addr == i.addr)
       {
-        found_change = true;
         continue;
       }
       if (i.addr == addr)

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -282,7 +282,7 @@ namespace cryptonote
 }
 
 BOOST_CLASS_VERSION(cryptonote::tx_source_entry, 1)
-BOOST_CLASS_VERSION(cryptonote::tx_destination_entry, 2)
+BOOST_CLASS_VERSION(cryptonote::tx_destination_entry, 3)
 
 namespace boost
 {
@@ -319,6 +319,9 @@ namespace boost
       }
       a & x.original;
       a & x.is_integrated;
+      if (ver < 3)
+        return;
+      a & x.asset_id;
     }
   }
 }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2412,7 +2412,8 @@ bool simple_wallet::frozen(const std::vector<std::string> &args)
       if (!m_wallet->frozen(i))
         continue;
       const auto& td = m_wallet->get_transfer_details(i);
-      message_writer() << tr("Frozen: ") << td.m_key_image << " " << cryptonote::print_money(td.amount());
+      std::string asset_id_hex = td.m_asset_id != crypto::null_aid ? tools::type_to_hex(td.m_asset_id) : "";
+      message_writer() << tr("Frozen: ") << td.m_key_image << " " << format_amount_with_asset_id(*m_wallet, td.amount(), asset_id_hex);
     }
   }
   else
@@ -8595,37 +8596,36 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
     }
 
     // give user total and fee, and prompt to confirm
-    uint64_t total_fee = 0, total_unmixable = 0;
+    uint64_t total_fee = 0;
+    std::map<crypto::asset_id, uint64_t> amounts_unmixable;
     for (size_t n = 0; n < ptx_vector.size(); ++n)
     {
       total_fee += ptx_vector[n].fee;
-      std::optional<crypto::asset_id> swept_asset_id;
-      for (const auto &dt: ptx_vector[n].dests)
-      {
-        if (dt.asset_id != crypto::null_aid)
-        {
-          swept_asset_id = dt.asset_id;
-          break;
-        }
-      }
       for (auto i: ptx_vector[n].selected_transfers)
       {
         const auto& td = m_wallet->get_transfer_details(i);
-        if (!swept_asset_id || td.get_asset_id() == *swept_asset_id)
-          total_unmixable += td.amount();
+        amounts_unmixable[td.get_asset_id()] += td.amount();
       }
     }
 
-    std::string prompt_str = tr("Sweeping ") + print_money(total_unmixable);
+    std::string sent_str;
+    for (const auto& [asset_id, amount] : amounts_unmixable)
+    {
+      if (!sent_str.empty())
+        sent_str += " and ";
+      sent_str += format_amount_with_asset_id(*m_wallet, amount, asset_id == crypto::null_aid ? "" : tools::type_to_hex(asset_id), true);
+    }
+
+    std::string prompt_str = tr("Sweeping ") + sent_str;
     if (ptx_vector.size() > 1) {
       prompt_str = fmt::format(tr("Sweeping {} in {} transactions for a total fee of {}. Is this okay?\n"),
-                               print_money(total_unmixable),
+                               sent_str,
                                ((unsigned long long)ptx_vector.size()),
                                print_money(total_fee)); 
     }
     else {
       prompt_str = fmt::format(tr("Sweeping {} for a total fee of {}. Is this okay?\n"),
-                               print_money(total_unmixable),
+                               sent_str,
                                print_money(total_fee)); 
     }
     std::string accepted = input_line(prompt_str, true);
@@ -8723,29 +8723,28 @@ bool simple_wallet::sweep_main_internal(sweep_type_t sweep_type, std::vector<too
   }
 
   // give user total and fee, and prompt to confirm
-  uint64_t total_fee = 0, total_sent = 0;
+  uint64_t total_fee = 0;
+  std::map<crypto::asset_id, uint64_t> amounts_sent;
   for (size_t n = 0; n < ptx_vector.size(); ++n)
   {
     total_fee += ptx_vector[n].fee;
-    std::optional<crypto::asset_id> swept_asset_id;
-    for (const auto &dt: ptx_vector[n].dests)
-    {
-      if (dt.asset_id != crypto::null_aid)
-      {
-        swept_asset_id = dt.asset_id;
-        break;
-      }
-    }
 
     for (auto i: ptx_vector[n].selected_transfers)
     {
       const auto& td = m_wallet->get_transfer_details(i);
-      if (!swept_asset_id || td.get_asset_id() == *swept_asset_id)
-        total_sent += td.amount();
+      amounts_sent[td.get_asset_id()] += td.amount();
     }
 
     if (sweep_type == sweep_type_t::stake || sweep_type == sweep_type_t::register_stake)
-      total_sent -= ptx_vector[n].change_dts.amount + ptx_vector[n].fee;
+      amounts_sent[crypto::null_aid] -= ptx_vector[n].change_dts.amount + ptx_vector[n].fee;
+  }
+
+  std::string sent_str;
+  for (const auto& [asset_id, amount] : amounts_sent)
+  {
+    if (!sent_str.empty())
+      sent_str += " and ";
+    sent_str += format_amount_with_asset_id(*m_wallet, amount, asset_id == crypto::null_aid ? "" : tools::type_to_hex(asset_id), true);
   }
 
   std::ostringstream prompt;
@@ -8769,14 +8768,14 @@ bool simple_wallet::sweep_main_internal(sweep_type_t sweep_type, std::vector<too
   if (ptx_vector.size() > 1) {
     prompt << fmt::format(tr("{} {} in {} transactions for a total fee of {}. Is this okay?\n"),
                           label,
-                          print_money(total_sent),
+                          sent_str,
                           ((unsigned long long)ptx_vector.size()),
                           print_money(total_fee)); 
   }
   else {
     prompt << fmt::format(tr("{} {} for a total fee of {}. Is this okay?\n"),
                           label,
-                          print_money(total_sent),
+                          sent_str,
                           print_money(total_fee)); 
   }
   std::string accepted = input_line(prompt.str(), true);
@@ -11658,6 +11657,7 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
   }
 
   const uint64_t last_block_height = m_wallet->get_blockchain_current_height();
+  bool found = false;
 
   std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> payments;
   m_wallet->get_payments(payments, 0, (uint64_t)-1, m_current_subaddress_account);
@@ -11706,7 +11706,7 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
       success_msg_writer() << "Checkpointed: " << (pd.m_unmined_flash ? "Flash" : pd.m_block_height <= m_wallet->get_immutable_height() ? "Yes" : pd.m_was_flash ? "Flash" : "No");
       success_msg_writer() << "Address index: " << pd.m_subaddr_index.minor;
       success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
-      return true;
+      found = true;
     }
   }
 
@@ -11769,7 +11769,7 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
           success_msg_writer() << "locked for " << tools::get_human_readable_timespan(std::chrono::seconds(pd.m_unlock_time - threshold));
       }
       success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
-      return true;
+      found = true;
     }
   }
 
@@ -11793,7 +11793,7 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
         success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
         if (i->second.m_double_spend_seen)
           success_msg_writer() << tr("Double spend seen on the network: this transaction may or may not end up being mined");
-        return true;
+        found = true;
       }
     }
   }
@@ -11837,11 +11837,13 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
       success_msg_writer() << "Change: " << format_amount_with_asset_id(*m_wallet, pd.m_change, transfer_asset_id);
       success_msg_writer() << "Fee: " << print_money(fee);
       success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
-      return true;
+      found = true;
     }
   }
 
-  fail_msg_writer() << tr("Transaction ID not found");
+  if (!found)
+    fail_msg_writer() << tr("Transaction ID not found");
+  
   return true;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6565,7 +6565,7 @@ bool simple_wallet::locked_transfer(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::locked_sweep_all(const std::vector<std::string> &args_)
 {
-  return sweep_main(m_current_subaddress_account, 0, Transfer::Locked, args_);
+  return sweep_main(m_current_subaddress_account, 0, Transfer::Locked, args_, true);
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::register_master_node(const std::vector<std::string> &args_)
@@ -8606,11 +8606,13 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
         const auto& td = m_wallet->get_transfer_details(i);
         amounts_unmixable[td.get_asset_id()] += td.amount();
       }
+      amounts_unmixable[crypto::null_aid] -= ptx_vector[n].change_dts.amount + ptx_vector[n].fee;
     }
 
     std::string sent_str;
     for (const auto& [asset_id, amount] : amounts_unmixable)
     {
+      if (amount == 0) continue;
       if (!sent_str.empty())
         sent_str += " and ";
       sent_str += format_amount_with_asset_id(*m_wallet, amount, asset_id == crypto::null_aid ? "" : tools::type_to_hex(asset_id), true);
@@ -8735,13 +8737,16 @@ bool simple_wallet::sweep_main_internal(sweep_type_t sweep_type, std::vector<too
       amounts_sent[td.get_asset_id()] += td.amount();
     }
 
-    if (sweep_type == sweep_type_t::stake || sweep_type == sweep_type_t::register_stake)
-      amounts_sent[crypto::null_aid] -= ptx_vector[n].change_dts.amount + ptx_vector[n].fee;
+    // Always subtract the BDX change and the BDX fee from the BDX inputs.
+    // This ensures that if BDX was only pulled in to pay the fee for an asset
+    // transfer, its net "swept" amount becomes 0 and won't be misleadingly shown.
+    amounts_sent[crypto::null_aid] -= ptx_vector[n].change_dts.amount + ptx_vector[n].fee;
   }
 
   std::string sent_str;
   for (const auto& [asset_id, amount] : amounts_sent)
   {
+    if (amount == 0) continue;
     if (!sent_str.empty())
       sent_str += " and ";
     sent_str += format_amount_with_asset_id(*m_wallet, amount, asset_id == crypto::null_aid ? "" : tools::type_to_hex(asset_id), true);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2554,6 +2554,21 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
       ++i;
   }
 
+  // HF21: Also suppress asset change outputs sent back to the spending account.
+  // Asset amounts are in different units so we don't add them to sub_change;
+  // instead we track them separately so the consistency check stays valid.
+  uint64_t asset_sub_change = 0;
+  for (auto i = tx_money_got_in_outs.begin(); i != tx_money_got_in_outs.end();)
+  {
+    if (subaddr_account && i->index.major == *subaddr_account && i->asset_id != crypto::null_aid)
+    {
+      asset_sub_change += i->amount;
+      i = tx_money_got_in_outs.erase(i);
+    }
+    else
+      ++i;
+  }
+
   // create payment_details for each incoming transfer to a subaddress index
   crypto::hash payment_id = null_hash;
   if (tx_money_got_in_outs.size() > 0 || earliest_flash_got_mined_transfers_index != NO_FLASH_MINED_INDEX)
@@ -2607,7 +2622,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 
   if (tx_money_got_in_outs.size() > 0)
   {
-    uint64_t total_received_2 = sub_change;
+    uint64_t total_received_2 = sub_change + asset_sub_change;
     for (const auto& i : tx_money_got_in_outs)
       total_received_2 += i.amount;
 
@@ -6379,7 +6394,7 @@ wallet::transfer_view wallet2::make_transfer_view(const crypto::hash &txid, cons
   {
     for (auto it = m_transfers.rbegin(); it != m_transfers.rend(); ++it)
     {
-      if (it->m_txid == pd.m_tx_hash && it->m_asset_id != crypto::null_aid)
+      if (it->m_txid == pd.m_tx_hash && it->m_asset_id != crypto::null_aid && it->amount() == pd.m_amount)
       {
         deduced_asset_id = it->m_asset_id;
         break;
@@ -6444,8 +6459,16 @@ wallet::transfer_view wallet2::wallet2::make_transfer_view(const crypto::hash &t
     }
   }
 
+  bool has_any_zarcanum_dest = false;
+  for (const auto& d : pd.m_dests) {
+    if (d.is_zarcanum()) {
+      has_any_zarcanum_dest = true;
+      break;
+    }
+  }
+
   for (const auto &d: pd.m_dests) {
-    crypto::asset_id actual_asset_id = d.is_zarcanum() ? d.asset_id : deduced_asset_id;
+    crypto::asset_id actual_asset_id = (d.is_zarcanum() || has_any_zarcanum_dest) ? d.asset_id : deduced_asset_id;
     bool is_zarcanum = actual_asset_id != crypto::null_aid;
     if (d.amount == 0 && is_zarcanum)
       continue;
@@ -6487,7 +6510,16 @@ wallet::transfer_view wallet2::wallet2::make_transfer_view(const crypto::hash &t
   }
   else if (!pd.m_dests.empty())
   {
-    crypto::asset_id first_actual_asset_id = pd.m_dests.front().is_zarcanum() ? pd.m_dests.front().asset_id : deduced_asset_id;
+    crypto::asset_id first_actual_asset_id = crypto::null_aid;
+    for (const auto& d : pd.m_dests)
+    {
+      crypto::asset_id actual_asset_id = (d.is_zarcanum() || has_any_zarcanum_dest) ? d.asset_id : deduced_asset_id;
+      if (actual_asset_id != crypto::null_aid)
+      {
+        first_actual_asset_id = actual_asset_id;
+        break;
+      }
+    }
     if (first_actual_asset_id != crypto::null_aid)
     {
       if (pd.m_pay_type != wallet::pay_type::deploy_asset && pd.m_pay_type != wallet::pay_type::emit_asset)
@@ -6495,7 +6527,11 @@ wallet::transfer_view wallet2::wallet2::make_transfer_view(const crypto::hash &t
         result.asset_id = tools::type_to_hex(first_actual_asset_id);
         result.amount = 0;
         for (const auto& d : pd.m_dests)
-          result.amount += d.amount;
+        {
+          crypto::asset_id actual_asset_id = (d.is_zarcanum() || has_any_zarcanum_dest) ? d.asset_id : deduced_asset_id;
+          if (actual_asset_id == first_actual_asset_id)
+            result.amount += d.amount;
+        }
       }
     }
   }
@@ -6551,8 +6587,16 @@ wallet::transfer_view wallet2::make_transfer_view(const crypto::hash &txid, cons
     }
   }
 
+  bool has_any_zarcanum_dest = false;
+  for (const auto& d : pd.m_dests) {
+    if (d.is_zarcanum()) {
+      has_any_zarcanum_dest = true;
+      break;
+    }
+  }
+
   for (const auto &d: pd.m_dests) {
-    crypto::asset_id actual_asset_id = d.is_zarcanum() ? d.asset_id : deduced_asset_id;
+    crypto::asset_id actual_asset_id = (d.is_zarcanum() || has_any_zarcanum_dest) ? d.asset_id : deduced_asset_id;
     bool is_zarcanum = actual_asset_id != crypto::null_aid;
     if (d.amount == 0 && is_zarcanum)
       continue;
@@ -6595,7 +6639,16 @@ wallet::transfer_view wallet2::make_transfer_view(const crypto::hash &txid, cons
   }
   else if (!pd.m_dests.empty())
   {
-    crypto::asset_id first_actual_asset_id = pd.m_dests.front().is_zarcanum() ? pd.m_dests.front().asset_id : deduced_asset_id;
+    crypto::asset_id first_actual_asset_id = crypto::null_aid;
+    for (const auto& d : pd.m_dests)
+    {
+      crypto::asset_id actual_asset_id = (d.is_zarcanum() || has_any_zarcanum_dest) ? d.asset_id : deduced_asset_id;
+      if (actual_asset_id != crypto::null_aid)
+      {
+        first_actual_asset_id = actual_asset_id;
+        break;
+      }
+    }
     if (first_actual_asset_id != crypto::null_aid)
     {
       if (pd.m_pay_type != wallet::pay_type::deploy_asset && pd.m_pay_type != wallet::pay_type::emit_asset)
@@ -6603,7 +6656,11 @@ wallet::transfer_view wallet2::make_transfer_view(const crypto::hash &txid, cons
         result.asset_id = tools::type_to_hex(first_actual_asset_id);
         result.amount = 0;
         for (const auto& d : pd.m_dests)
-          result.amount += d.amount;
+        {
+          crypto::asset_id actual_asset_id = (d.is_zarcanum() || has_any_zarcanum_dest) ? d.asset_id : deduced_asset_id;
+          if (actual_asset_id == first_actual_asset_id)
+            result.amount += d.amount;
+        }
       }
     }
   }
@@ -8449,7 +8506,7 @@ bool wallet2::find_and_save_rings(bool force)
   {
     size_t ntxes = slice + SLICE_SIZE > txs_hashes.size() ? txs_hashes.size() - slice : SLICE_SIZE;
     nlohmann::json get_transactions_params{
-      {"txs_hashes", {hashes_to_hex(txs_hashes.begin() + slice, txs_hashes.begin() + ntxes)}},
+      {"txs_hashes", hashes_to_hex(txs_hashes.begin() + slice, txs_hashes.begin() + slice + ntxes)},
       {"data",true}
     };
     auto res = m_http_client.json_rpc("get_transactions", get_transactions_params);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1776,7 +1776,7 @@ private:
 
 }
 BOOST_CLASS_VERSION(tools::wallet2, 30)
-BOOST_CLASS_VERSION(tools::wallet2::payment_details, 6)
+BOOST_CLASS_VERSION(tools::wallet2::payment_details, 7)
 BOOST_CLASS_VERSION(tools::wallet2::pool_payment_details, 1)
 BOOST_CLASS_VERSION(tools::wallet2::unconfirmed_transfer_details, 9)
 BOOST_CLASS_VERSION(tools::wallet2::confirmed_transfer_details, 8)
@@ -1943,6 +1943,12 @@ namespace boost::serialization
       a & x.m_unmined_flash;
       if (ver < 6) return;
       a & x.m_was_flash;
+      if (ver < 7)
+      {
+        x.m_asset_id = crypto::null_aid;
+        return;
+      }
+      a & x.m_asset_id;
     }
 
     template <class Archive>


### PR DESCRIPTION

* Bumped `payment_details` serialization version to 7 and properly serialized `m_asset_id` so incoming token types survive wallet restarts.
* Fixed consistency failure crashes on incoming asset change outputs by properly isolating `asset_sub_change` from native BDX change in `process_new_transaction`.
* Refactored `sweep_all`, `sweep_single`, and `sweep_unmixable` confirmation prompts to correctly group and format amounts by asset ID, rather than blindly summing the raw atomic units of different assets.
* Updated `sweep_main_internal` to subtract BDX change and fees across all sweep types, accurately hiding BDX amounts pulled purely to pay for token fees from the user prompt.
* Added the `plain_address_sweeps_all_assets` flag to `locked_sweep_all` so it correctly identifies and sweeps confidential assets alongside native BDX.
* Fixed the `show_transfer` command to iterate and print all matching payments for a given `txid` (e.g., in a mixed-asset transaction) instead of prematurely exiting after printing the first output.