### PR TITLE
wallet: fix offline ZC fee estimation and modified update_asset

### DIFF
--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -225,6 +225,9 @@ namespace boost
       a & (rct::rctSigBase&)x.rct_signatures;
       if (x.rct_signatures.type != rct::RCTType::Null)
         a & x.rct_signatures.p;
+
+      if (ver >= 1)
+        a & x.asset_proofs;
     }
   }
 
@@ -434,9 +437,94 @@ namespace boost
     a & x.range_proof_type;
     a & x.bp_version;
   }
+  template <class Archive>
+  inline void serialize(Archive &a, crypto::schnorr_sig_s &x, const boost::serialization::version_type ver)
+  {
+    a & x.y;
+    a & x.c;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, crypto::linear_composition_proof_s &x, const boost::serialization::version_type ver)
+  {
+    a & x.y0;
+    a & x.y1;
+    a & x.c;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, crypto::double_schnorr_sig_s &x, const boost::serialization::version_type ver)
+  {
+    a & x.y0;
+    a & x.y1;
+    a & x.c;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, crypto::BGE_proof_s &x, const boost::serialization::version_type ver)
+  {
+    a & x.A;
+    a & x.B;
+    a & x.Pk;
+    a & x.f;
+    a & x.y;
+    a & x.z;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, crypto::vector_ug_aggregation_proof_s &x, const boost::serialization::version_type ver)
+  {
+    a & x.amount_commitments_for_rp_aggregation;
+    a & x.y0s;
+    a & x.y1s;
+    a & x.c;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, rct::clsag_ggx &x, const boost::serialization::version_type ver)
+  {
+    a & x.s_g;
+    a & x.s_x;
+    a & x.c1;
+    a & x.D;
+    a & x.E;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, rct::zc_asset_surjection_proof &x, const boost::serialization::version_type ver)
+  {
+    a & x.bge_proofs;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, rct::zc_balance_proof &x, const boost::serialization::version_type ver)
+  {
+    a & x.P;
+    a & x.dss;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, rct::asset_operation_proof &x, const boost::serialization::version_type ver)
+  {
+    a & x.flags;
+    if (x.has_composition_proof())
+      a & x.composition_proof;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, rct::asset_operation_ownership_proof &x, const boost::serialization::version_type ver)
+  {
+    a & x.sig;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, rct::ZC_sig &x, const boost::serialization::version_type ver)
+  {
+    a & x.clsag_sig;
+    a & x.pseudo_out_amount_commitment;
+    a & x.pseudo_out_blinded_asset_id;
+  }
+  template <class Archive>
+  inline void serialize(Archive &a, rct::zc_outs_range_proof &x, const boost::serialization::version_type ver)
+  {
+    a & x.bpp;
+    a & x.aggregation_proof;
+  }
 }
 }
+
 
 BOOST_CLASS_VERSION(rct::rctSigPrunable, 2)
 BOOST_CLASS_VERSION(rct::rctSig, 2)
 BOOST_CLASS_VERSION(rct::multisig_out, 1)
+BOOST_CLASS_VERSION(cryptonote::transaction, 1)

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -481,6 +481,32 @@ namespace cryptonote
     const size_t n_padded_outputs = bulletproof_plus ? rct::n_bulletproof_plus_max_amounts(rv.p.bulletproofs_plus) : rct::n_bulletproof_max_amounts(rv.p.bulletproofs);
     uint64_t bp_clawback = get_transaction_weight_clawback(tx, n_padded_outputs);
     CHECK_AND_ASSERT_THROW_MES_L1(bp_clawback <= std::numeric_limits<uint64_t>::max() - blob_size, "Weight overflow");
+    
+    // Add artificial weight padding for view wallets missing Zarcanum asset proofs
+    if (tx.version >= txversion::v4_tx_types && tx.asset_proofs.empty())
+    {
+      size_t num_zc_inputs = 0;
+      for (const auto& in : tx.vin)
+        if (std::holds_alternative<txin_zc_input>(in))
+          num_zc_inputs++;
+          
+      size_t num_zc_outputs = 0;
+      for (const auto& out : tx.vout)
+        if (std::holds_alternative<tx_out_zarcanum>(out.target))
+          num_zc_outputs++;
+          
+      if (num_zc_inputs > 0 || num_zc_outputs > 0)
+      {
+        size_t estimated_asset_proofs_size = 0;
+        estimated_asset_proofs_size += num_zc_inputs * 928;
+        estimated_asset_proofs_size += num_zc_outputs * 516;
+        if (num_zc_outputs > 0) estimated_asset_proofs_size += 640;
+
+        estimated_asset_proofs_size += 512; // padding for vector lengths
+        return blob_size + bp_clawback + estimated_asset_proofs_size;
+      }
+    }
+
     return blob_size + bp_clawback;
   }
   //---------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1526,9 +1526,11 @@ namespace cryptonote
           }
           const rct::key asset_proof_message = rct::get_hf21_asset_proof_message(tx, input_rings, hwdev);
 
-          // ── HF21: ZC_sig generation for zarcanum inputs ──────────────────────
-          // Deferred until now since the ring signature message depends on
-          // the finalized tx. zc_pending is index-aligned with the final
+          if (!zero_secret_key)
+          {
+            // ── HF21: ZC_sig generation for zarcanum inputs ──────────────────────
+            // Deferred until now since the ring signature message depends on
+            // the finalized tx. zc_pending is index-aligned with the final
           // tx.vin order, so the resulting ZC_sigs come out in the same
           // relative order as their zarcanum inputs (matching
           // verAssetProofs's matching convention).
@@ -1819,6 +1821,7 @@ namespace cryptonote
             tx.asset_proofs.push_back(std::move(ownership_proof));
             MINFO("Attached ownership proof for emit_asset/update_asset tx: " << get_transaction_hash(tx));
           }
+          } // if (!zero_secret_key)
 
           memwipe(inSk.data(), inSk.size() * sizeof(rct::ctkey));
 

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -281,7 +281,7 @@ namespace cryptonote
 
 }
 
-BOOST_CLASS_VERSION(cryptonote::tx_source_entry, 1)
+BOOST_CLASS_VERSION(cryptonote::tx_source_entry, 2)
 BOOST_CLASS_VERSION(cryptonote::tx_destination_entry, 3)
 
 namespace boost
@@ -302,6 +302,11 @@ namespace boost
         return;
       a & x.multisig_kLRki;
       a & x.real_out_additional_tx_keys;
+      if (ver < 2)
+        return;
+      a & x.asset_id;
+      a & x.asset_mask;
+      a & x.ring_blinded_asset_ids;
     }
 
     template <class Archive>

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8497,13 +8497,16 @@ bool simple_wallet::update_asset(const std::vector<std::string>& args_)
     fail_msg_writer() << error << ": " << args[1];
     return false;
   }
-  if (file_adb.meta_info == adb.meta_info)
+  if (file_adb.meta_info == adb.meta_info && file_adb.owner == adb.owner)
   {
-    fail_msg_writer() << tr("update_asset: meta_info is unchanged, nothing to update");
+    fail_msg_writer() << tr("update_asset: meta_info and owner are unchanged, nothing to update");
     return false;
   }
   adb.meta_info = file_adb.meta_info;
-
+  // Allow transferring ownership if the owner in the JSON file is different
+  if (file_adb.owner != crypto::null_pkey) {
+    adb.owner = file_adb.owner;
+  }
   SCOPED_WALLET_UNLOCK();
 
   try
@@ -9184,9 +9187,13 @@ bool simple_wallet::sweep_below(const std::vector<std::string> &args_)
 bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes, const std::function<const wallet::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
 {
   // gather info to ask the user
-  uint64_t amount = 0, amount_to_dests = 0, change = 0;
+  std::map<crypto::asset_id, uint64_t> amounts, amounts_to_dests, changes;
   size_t min_ring_size = ~0;
-  std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
+  struct dest_info {
+    std::string address;
+    std::map<crypto::asset_id, uint64_t> amounts;
+  };
+  std::unordered_map<cryptonote::account_public_address, dest_info> dests;
   int first_known_non_zero_change_index = -1;
   std::string payment_id_string = "";
   for (size_t n = 0; n < get_num_txes(); ++n)
@@ -9235,7 +9242,7 @@ bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes,
 
     for (size_t s = 0; s < cd.sources.size(); ++s)
     {
-      amount += cd.sources[s].amount;
+      amounts[cd.sources[s].asset_id] += cd.sources[s].amount;
       size_t ring_size = cd.sources[s].outputs.size();
       if (ring_size < min_ring_size)
         min_ring_size = ring_size;
@@ -9253,11 +9260,15 @@ bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes,
         address = standard_address;
       auto i = dests.find(entry.addr);
       if (i == dests.end())
-        dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+        dests.insert(std::make_pair(entry.addr, dest_info{address, {{entry.asset_id, entry.amount}}}));
       else
-        i->second.second += entry.amount;
-      amount_to_dests += entry.amount;
+        i->second.amounts[entry.asset_id] += entry.amount;
+      amounts_to_dests[entry.asset_id] += entry.amount;
     }
+    std::map<crypto::asset_id, uint64_t> explicit_amounts;
+    for (size_t d = 0; d < cd.dests.size(); ++d)
+      explicit_amounts[cd.dests[d].asset_id] += cd.dests[d].amount;
+
     if (cd.change_dts.amount > 0)
     {
       auto it = dests.find(cd.change_dts.addr);
@@ -9266,25 +9277,45 @@ bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes,
         fail_msg_writer() << tr("Claimed change does not go to a paid address");
         return false;
       }
-      if (it->second.second < cd.change_dts.amount)
+      if (it->second.amounts[cd.change_dts.asset_id] < cd.change_dts.amount)
       {
         fail_msg_writer() << tr("Claimed change is larger than payment to the change address");
         return false;
       }
-      if (cd.change_dts.amount > 0)
+      if (first_known_non_zero_change_index == -1)
+        first_known_non_zero_change_index = n;
+      if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
       {
-        if (first_known_non_zero_change_index == -1)
-          first_known_non_zero_change_index = n;
-        if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+        fail_msg_writer() << tr("Change goes to more than one address");
+        return false;
+      }
+      changes[cd.change_dts.asset_id] += cd.change_dts.amount;
+      it->second.amounts[cd.change_dts.asset_id] -= cd.change_dts.amount;
+      if (it->second.amounts[cd.change_dts.asset_id] == 0)
+        it->second.amounts.erase(cd.change_dts.asset_id);
+      if (it->second.amounts.empty())
+        dests.erase(cd.change_dts.addr);
+    }
+
+    for (const auto& [asset_id, amt] : amounts)
+    {
+      if (asset_id == crypto::null_aid)
+        continue;
+      uint64_t explicit_amt = explicit_amounts[asset_id];
+      if (amt > explicit_amt)
+      {
+        uint64_t asset_change = amt - explicit_amt;
+        auto it = dests.find(cd.change_dts.addr);
+        if (it != dests.end())
         {
-          fail_msg_writer() << tr("Change goes to more than one address");
-          return false;
+          changes[asset_id] += asset_change;
+          it->second.amounts[asset_id] -= asset_change;
+          if (it->second.amounts[asset_id] == 0)
+            it->second.amounts.erase(asset_id);
+          if (it->second.amounts.empty())
+            dests.erase(cd.change_dts.addr);
         }
       }
-      change += cd.change_dts.amount;
-      it->second.second -= cd.change_dts.amount;
-      if (it->second.second == 0)
-        dests.erase(cd.change_dts.addr);
     }
   }
 
@@ -9295,11 +9326,21 @@ bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes,
   size_t n_dummy_outputs = 0;
   for (auto i = dests.begin(); i != dests.end(); )
   {
-    if (i->second.second > 0)
+    if (!i->second.amounts.empty())
     {
-      if (!dest_string.empty())
-        dest_string += ", ";
-      dest_string += (boost::format(tr("sending %s to %s")) % print_money(i->second.second) % i->second.first).str();
+      std::string amounts_str;
+      for (const auto& [asset_id, amt] : i->second.amounts)
+      {
+        if (amt == 0) continue;
+        if (!amounts_str.empty()) amounts_str += " and ";
+        amounts_str += format_amount_with_asset_id(*m_wallet, amt, asset_id == crypto::null_aid ? "" : tools::type_to_hex(asset_id), true);
+      }
+      if (!amounts_str.empty())
+      {
+        if (!dest_string.empty())
+          dest_string += ", ";
+        dest_string += (boost::format(tr("sending %s to %s")) % amounts_str % i->second.address).str();
+      }
     }
     else
       ++n_dummy_outputs;
@@ -9315,16 +9356,31 @@ bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes,
     dest_string = tr("with no destinations");
 
   std::string change_string;
-  if (change > 0)
+  if (!changes.empty())
   {
+    std::string amounts_str;
+    for (const auto& [asset_id, amt] : changes)
+    {
+      if (amt == 0) continue;
+      if (!amounts_str.empty()) amounts_str += " and ";
+      amounts_str += format_amount_with_asset_id(*m_wallet, amt, asset_id == crypto::null_aid ? "" : tools::type_to_hex(asset_id), true);
+    }
     std::string address = get_account_address_as_str(m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
-    change_string += (boost::format(tr("%s change to %s")) % print_money(change) % address).str();
+    change_string += (boost::format(tr("%s change to %s")) % amounts_str % address).str();
   }
   else
     change_string += tr("no change");
 
-  uint64_t fee = amount - amount_to_dests;
-  std::string prompt_str = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?")) % (unsigned long)get_num_txes() % print_money(amount) % print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
+  uint64_t fee = amounts[crypto::null_aid] - amounts_to_dests[crypto::null_aid];
+  std::string total_amounts_str;
+  for (const auto& [asset_id, amt] : amounts)
+  {
+    if (amt == 0) continue;
+    if (!total_amounts_str.empty()) total_amounts_str += " and ";
+    total_amounts_str += format_amount_with_asset_id(*m_wallet, amt, asset_id == crypto::null_aid ? "" : tools::type_to_hex(asset_id), true);
+  }
+  
+  std::string prompt_str = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?")) % (unsigned long)get_num_txes() % total_amounts_str % print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
   return command_line::is_yes(input_line(prompt_str, true));
 }
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- fix(wallet): add artificial weight padding to `get_transaction_weight` for view-only wallets to accurately estimate fees for offline-signed Zarcanum transactions.
- fix(core): add missing Boost serialization templates for Zarcanum ZK primitives (`zc_outs_range_proof`, etc.) to fix blockchain utilities compilation.
- feat(wallet): modified `update_asset` to support transferring asset ownership when a new owner public key is specified in the JSON descriptor.