### PR TITLE
Add multi-asset support to Wallet API and asset operation tests

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -439,8 +439,11 @@ namespace cryptonote
           }
 
           // HF21: confidential asset proofs (present when has_zarcanum_outputs()
-          // or for update_asset txs).
-          if (!asset_proofs.empty() || has_zarcanum_outputs() || type == txtype::update_asset)
+          // or for update_asset/burn_asset txs). Burn-all transactions can
+          // consume confidential inputs without producing any confidential
+          // outputs, so the tx type must participate in the deserialization
+          // gate or the trailing proof bytes will be left unread.
+          if (!asset_proofs.empty() || has_zarcanum_outputs() || type == txtype::update_asset || type == txtype::burn_asset)
           {
             ar.tag("asset_proofs");
             serialization::value(ar, asset_proofs);

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1580,11 +1580,11 @@ namespace cryptonote
         // (blob.substr(unprunable_size) covers them), so this re-serialize path
         // must emit them too, zc_sig first then asset_proofs, under the SAME
         // presence gates as transaction::serialize_value, or the prunable hash
-        // won't match for CA txs (zc inputs/outputs and update_asset carry their
-        // sigs/proofs here, not in the native CLSAG/bulletproof arrays).
+        // won't match for CA txs (zc inputs/outputs and update_asset/burn_asset
+        // carry their sigs/proofs here, not in the native CLSAG/bulletproof arrays).
         if (t.has_zarcanum_inputs())
           serialization::value(ba, const_cast<transaction&>(t).zc_sig);
-        if (!t.asset_proofs.empty() || t.has_zarcanum_outputs() || t.type == txtype::update_asset)
+        if (!t.asset_proofs.empty() || t.has_zarcanum_outputs() || t.type == txtype::update_asset || t.type == txtype::burn_asset)
           serialization::value(ba, const_cast<transaction&>(t).asset_proofs);
       } catch (const std::exception& e) {
         LOG_ERROR("Failed to serialize rct signatures (prunable): " << e.what());

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -45,10 +45,13 @@
 #include "common_defines.h"
 #include "common/util.h"
 #include "common/fs.h"
+#include "cryptonote_basic/asset_descriptor_operation_utils.h"
 
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
 #include <boost/format.hpp>
+#include <cctype>
+#include <rapidjson/document.h>
 #include <sstream>
 #include <unordered_map>
 #include <thread>
@@ -79,6 +82,154 @@ namespace {
       else if (nettype == cryptonote::network_type::DEVNET)
         dir /= "devnet";
       return dir;
+    }
+
+    bool is_native_sweep_request(const std::optional<std::string>& asset_id)
+    {
+        if (!asset_id) return false;
+        return asset_id->empty() || *asset_id == "BDX" || *asset_id == "bdx" ||
+               *asset_id == "native" || *asset_id == "NATIVE";
+    }
+
+    bool validate_asset_descriptor_for_deploy(const cryptonote::asset_descriptor_base& descriptor, std::string& error)
+    {
+        auto ticker_ok = [](std::string_view ticker) {
+            return !ticker.empty() && ticker.size() <= 14 &&
+                   std::all_of(ticker.begin(), ticker.end(), [](unsigned char c) { return std::isalnum(c); });
+        };
+        auto full_name_ok = [](std::string_view name) {
+            return !name.empty() &&
+                   std::all_of(name.begin(), name.end(), [](unsigned char c) {
+                       return std::isalnum(c) || c == ' ' || c == '_' || c == '-' || c == '.';
+                   });
+        };
+
+        if (!ticker_ok(descriptor.ticker))
+        {
+            error = "ticker is invalid; expected 1-14 alphanumeric characters";
+            return false;
+        }
+        if (!full_name_ok(descriptor.full_name))
+        {
+            error = "full_name contains unsupported characters";
+            return false;
+        }
+        if (descriptor.decimal_point > 18)
+        {
+            error = "decimal_point must be <= 18";
+            return false;
+        }
+        if (descriptor.total_max_supply == 0)
+        {
+            error = "total_max_supply must be greater than 0";
+            return false;
+        }
+        if (descriptor.current_supply > descriptor.total_max_supply)
+        {
+            error = "current_supply cannot exceed total_max_supply";
+            return false;
+        }
+        if (descriptor.meta_info.length() > 4096)
+        {
+            error = "meta_info cannot exceed 4096 characters";
+            return false;
+        }
+        return true;
+    }
+
+    bool load_asset_descriptor_from_json(
+            std::string_view data,
+            cryptonote::asset_descriptor_base& descriptor,
+            std::string& error)
+    {
+        rapidjson::Document json;
+        if (json.Parse(data.data(), data.size()).HasParseError())
+        {
+            error = "invalid JSON";
+            return false;
+        }
+
+        if (!json.IsObject())
+        {
+            error = "top-level JSON must be an object";
+            return false;
+        }
+
+        auto get_string = [&](const char* key, std::string& out, bool required) -> bool {
+            auto it = json.FindMember(key);
+            if (it == json.MemberEnd())
+            {
+                if (required)
+                {
+                    error = std::string{"missing required field: "} + key;
+                    return false;
+                }
+                return true;
+            }
+            if (!it->value.IsString())
+            {
+                error = std::string{"field '"} + key + "' must be a string";
+                return false;
+            }
+            out = {it->value.GetString(), it->value.GetStringLength()};
+            return true;
+        };
+
+        auto get_uint = [&](const char* key, uint64_t& out, bool required) -> bool {
+            auto it = json.FindMember(key);
+            if (it == json.MemberEnd())
+            {
+                if (required)
+                {
+                    error = std::string{"missing required field: "} + key;
+                    return false;
+                }
+                return true;
+            }
+            if (!it->value.IsUint64())
+            {
+                error = std::string{"field '"} + key + "' must be an unsigned integer";
+                return false;
+            }
+            out = it->value.GetUint64();
+            return true;
+        };
+
+        uint64_t decimal_point = 0;
+        std::string owner_str;
+
+        if (!get_string("ticker", descriptor.ticker, true) ||
+            !get_string("full_name", descriptor.full_name, true) ||
+            !get_string("meta_info", descriptor.meta_info, false) ||
+            !get_uint("total_max_supply", descriptor.total_max_supply, true) ||
+            !get_uint("current_supply", descriptor.current_supply, false) ||
+            !get_uint("decimal_point", decimal_point, false) ||
+            !get_string("owner", owner_str, false))
+            return false;
+
+        descriptor.decimal_point = decimal_point;
+        descriptor.owner = crypto::null_pkey;
+        if (!owner_str.empty())
+        {
+            cryptonote::address_parse_info owner_info{};
+            if (cryptonote::get_account_address_from_str(owner_info, cryptonote::network_type::MAINNET, owner_str) ||
+                cryptonote::get_account_address_from_str(owner_info, cryptonote::network_type::TESTNET, owner_str))
+            {
+                if (owner_info.is_subaddress)
+                {
+                    error = "field 'owner' cannot be a subaddress";
+                    return false;
+                }
+                descriptor.owner = owner_info.address.m_spend_public_key;
+            }
+            else if (!tools::hex_to_type(owner_str, descriptor.owner))
+            {
+                error = "field 'owner' must be a valid public key hex string or address";
+                return false;
+            }
+        }
+
+        return true;
     }
 
     void checkMultisigWalletReady(LockedWallet& wallet) {
@@ -1057,6 +1208,60 @@ uint64_t WalletImpl::balance(uint32_t accountIndex) const
 }
 
 EXPORT
+std::vector<AssetBalanceInfo> WalletImpl::assetBalances(uint32_t accountIndex) const
+{
+    auto w = wallet();
+
+    const auto asset_balances_by_subaddr = w->asset_balances_per_subaddress(accountIndex, false);
+    const auto unlocked_asset_balances_by_subaddr = w->unlocked_asset_balances_per_subaddress(accountIndex, true);
+
+    std::map<crypto::asset_id, uint64_t> total_by_asset;
+    std::map<crypto::asset_id, uint64_t> unlocked_by_asset;
+
+    for (const auto& [subaddr_index, asset_balances] : asset_balances_by_subaddr)
+    {
+        for (const auto& [asset_id, amount] : asset_balances)
+            total_by_asset[asset_id] += amount;
+    }
+
+    for (const auto& [subaddr_index, asset_balances] : unlocked_asset_balances_by_subaddr)
+    {
+        for (const auto& [asset_id, amount] : asset_balances)
+            unlocked_by_asset[asset_id] += amount;
+    }
+
+    std::vector<AssetBalanceInfo> result;
+    result.reserve(total_by_asset.size());
+
+    for (const auto& [asset_id, balance] : total_by_asset)
+    {
+        AssetBalanceInfo entry;
+        entry.assetId = tools::type_to_hex(asset_id);
+        entry.balance = balance;
+        if (const auto it = unlocked_by_asset.find(asset_id); it != unlocked_by_asset.end())
+            entry.unlockedBalance = it->second;
+
+        try
+        {
+            nlohmann::json info_req = nlohmann::json::object();
+            info_req["asset_id"] = entry.assetId;
+            const nlohmann::json info_res = w->json_rpc("get_asset_info", info_req);
+            entry.ticker = info_res.value("ticker", "");
+            entry.decimalPoint = static_cast<uint8_t>(info_res.value("decimal_point", 0));
+        }
+        catch (const std::exception&)
+        {
+            // Best-effort metadata lookup: keep balances even if the daemon
+            // cannot supply ticker/decimal-point information right now.
+        }
+
+        result.push_back(std::move(entry));
+    }
+
+    return result;
+}
+
+EXPORT
 uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex) const
 {
     return wallet()->unlocked_balance(accountIndex, false);
@@ -1598,7 +1803,7 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const std::string& si
 //    - confirmed_transfer_details)
 
 EXPORT
-PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std::string> &dst_addr, std::optional<std::vector<uint64_t>> amount, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std::string> &dst_addr, std::optional<std::vector<uint64_t>> amount, std::optional<std::string> asset_id, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 
 {
     clearStatus();
@@ -1613,6 +1818,15 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std:
         std::vector<uint8_t> extra;
         std::string extra_nonce;
         std::vector<cryptonote::tx_destination_entry> dsts;
+        std::optional<crypto::asset_id> requested_asset_id;
+        if (asset_id) {
+            crypto::asset_id parsed_asset_id = crypto::null_aid;
+            if (!tools::hex_to_type(*asset_id, parsed_asset_id)) {
+                setStatusError(tr("Invalid asset id"));
+                break;
+            }
+            requested_asset_id = parsed_asset_id;
+        }
         if (!amount && dst_addr.size() > 1) {
             setStatusError(tr("Sending all requires one destination address"));
             break;
@@ -1642,11 +1856,13 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std:
 
             if (amount) {
                 cryptonote::tx_destination_entry de;
-                de.original = dst_addr[i];
-                de.addr = info.address;
+                de.original = dst_addr[i]; // original stirng
+                de.addr = info.address; // parsed address
                 de.amount = (*amount)[i];
                 de.is_subaddress = info.is_subaddress;
                 de.is_integrated = info.has_payment_id;
+                if (requested_asset_id)
+                    de.asset_id = *requested_asset_id;
                 dsts.push_back(de);
 
             } else {
@@ -1658,7 +1874,7 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std:
         }
         if (error) {
             break;
-        }
+        }// if payment id is present, add it to extra
         if (!extra_nonce.empty() && !add_extra_nonce_to_tx_extra(extra, extra_nonce)) {
             setStatusError(tr("failed to set up payment id, though it was decoded correctly"));
             break;
@@ -1678,7 +1894,7 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std:
             } else {
                 transaction->m_pending_tx = w->create_transactions_all(0, info.address, info.is_subaddress, 1, cryptonote::TX_OUTPUT_DECOYS, 0 /* unlock_time */,
                                                                               priority,
-                                                                              extra, subaddr_account, subaddr_indices);
+                                                                              extra, subaddr_account, subaddr_indices, requested_asset_id);
             }
             pendingTxPostProcess(transaction);
 
@@ -1758,14 +1974,14 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std:
 
 EXPORT
 PendingTransaction *WalletImpl::createTransaction(const std::string &dst_addr, std::optional<uint64_t> amount,
-                                                  uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+                                                  std::optional<std::string> asset_id, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 
 {
-    return createTransactionMultDest(std::vector<std::string> {dst_addr},  amount ? (std::vector<uint64_t> {*amount}) : (std::optional<std::vector<uint64_t>>()), priority, subaddr_account, subaddr_indices);
+    return createTransactionMultDest(std::vector<std::string> {dst_addr},  amount ? (std::vector<uint64_t> {*amount}) : (std::optional<std::vector<uint64_t>>()), asset_id, priority, subaddr_account, subaddr_indices);
 }
 
 EXPORT
-PendingTransaction *WalletImpl::createSweepAllTransaction(uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+PendingTransaction *WalletImpl::createSweepAllTransaction(std::optional<std::string> asset_id, std::optional<std::string> dst_addr, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 {
     clearStatus();
     // Pause refresh thread while creating transaction
@@ -1779,8 +1995,22 @@ PendingTransaction *WalletImpl::createSweepAllTransaction(uint32_t priority, uin
         auto w = wallet();
         std::vector<uint8_t> extra;
         std::string extra_nonce;
+        std::optional<crypto::asset_id> requested_asset_id;
+        const bool native_only = is_native_sweep_request(asset_id);
+        if (asset_id && !native_only) {
+            crypto::asset_id parsed_asset_id = crypto::null_aid;
+            if (!tools::hex_to_type(*asset_id, parsed_asset_id)) {
+                setStatusError(tr("Invalid asset id"));
+                break;
+            }
+            requested_asset_id = parsed_asset_id;
+        }
+        const auto selection_mode =
+                requested_asset_id ? tools::wallet2::sweep_selection_mode::native_only :
+                (native_only ? tools::wallet2::sweep_selection_mode::native_only :
+                               tools::wallet2::sweep_selection_mode::native_and_all_assets);
 
-        std::string addr = w->get_subaddress_as_str({0, 0});
+        std::string addr = dst_addr ? *dst_addr : w->get_subaddress_as_str({0, 0});
         if (!cryptonote::get_account_address_from_str(info, w->nettype(), addr)){
             setStatusError(tr("failed to parse address"));
             break;
@@ -1800,7 +2030,8 @@ PendingTransaction *WalletImpl::createSweepAllTransaction(uint32_t priority, uin
         try {
             transaction->m_pending_tx = w->create_transactions_all(0, info.address, info.is_subaddress, 1, cryptonote::TX_OUTPUT_DECOYS, 0 /* unlock_time */,
                                                                             priority,
-                                                                            extra, subaddr_account, subaddr_indices);
+                                                                            extra, subaddr_account, subaddr_indices, requested_asset_id,
+                                                                            cryptonote::txtype::standard, selection_mode);
             pendingTxPostProcess(transaction);
 
         } catch (const tools::error::daemon_busy&) {
@@ -1870,6 +2101,550 @@ PendingTransaction *WalletImpl::createSweepAllTransaction(uint32_t priority, uin
 
     transaction->m_status = status();
     // Resume refresh thread
+    startRefresh();
+    return transaction;
+}
+
+EXPORT
+PendingTransaction *WalletImpl::deployNewAssetTransaction(const std::string& descriptor_json, std::string& asset_id, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+{
+    clearStatus();
+    pauseRefresh();
+
+    PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
+    asset_id.clear();
+
+    do {
+        if (descriptor_json.empty()) {
+            setStatusError(tr("descriptor_json is required"));
+            break;
+        }
+
+        cryptonote::asset_descriptor_base descriptor{};
+        std::string error;
+        if (!load_asset_descriptor_from_json(descriptor_json, descriptor, error)) {
+            setStatusError(tr("Invalid asset descriptor JSON: ") + error);
+            break;
+        }
+
+        if (!validate_asset_descriptor_for_deploy(descriptor, error)) {
+            setStatusError(tr("Invalid asset descriptor: ") + error);
+            break;
+        }
+
+        auto w = wallet();
+        const auto owner = w->get_account().get_keys().m_account_address.m_spend_public_key;
+        if (descriptor.owner == crypto::null_pkey)
+            descriptor.owner = owner;
+        else if (descriptor.owner != owner) {
+            setStatusError(tr("Asset owner must be this wallet's spend key"));
+            break;
+        }
+
+        if (!w->get_hard_fork_version()) {
+            setStatusError(tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED);
+            break;
+        }
+
+        cryptonote::tx_extra_asset_descriptor_operation ado{};
+        ado.operation_type = cryptonote::asset_descriptor_operation_type::register_asset;
+        ado.fields = static_cast<uint8_t>(cryptonote::asset_field_descriptor |
+                                          cryptonote::asset_field_asset_id_salt);
+        ado.descriptor = descriptor;
+        ado.asset_id_salt = crypto::rand<uint32_t>();
+
+        std::vector<uint8_t> extra;
+        if (!cryptonote::add_asset_descriptor_operation_to_tx_extra(extra, ado)) {
+            setStatusError(tr("Failed to encode asset descriptor into tx extra"));
+            break;
+        }
+
+        const crypto::asset_id computed_asset_id = cryptonote::get_or_calculate_asset_id(ado);
+        asset_id = tools::type_to_hex(computed_asset_id);
+
+        std::vector<cryptonote::tx_destination_entry> dsts;
+        if (descriptor.current_supply > 0) {
+            cryptonote::tx_destination_entry dest;
+            dest.addr = w->get_account().get_keys().m_account_address;
+            dest.amount = descriptor.current_supply;
+            dest.asset_id = computed_asset_id;
+            dest.is_subaddress = false;
+            dsts.push_back(dest);
+        }
+
+        try {
+            transaction->m_pending_tx = w->create_asset_deploy_tx(
+                    dsts,
+                    computed_asset_id,
+                    cryptonote::TX_OUTPUT_DECOYS,
+                    priority,
+                    extra,
+                    subaddr_account,
+                    subaddr_indices);
+            pendingTxPostProcess(transaction);
+
+            if (multisig().isMultisig) {
+                auto tx_set = w->make_multisig_tx_set(transaction->m_pending_tx);
+                transaction->m_pending_tx = tx_set.m_ptx;
+                transaction->m_signers = tx_set.m_signers;
+            }
+        } catch (const tools::error::daemon_busy&) {
+            setStatusError(tr("daemon is busy. Please try again later."));
+        } catch (const tools::error::no_connection_to_daemon&) {
+            setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        } catch (const tools::error::wallet_rpc_error& e) {
+            setStatusError(tr("RPC error: ") + e.to_string());
+        } catch (const tools::error::get_outs_error &e) {
+            setStatusError((boost::format(tr("failed to get outputs to mix: %s")) % e.what()).str());
+        } catch (const tools::error::not_enough_unlocked_money& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            setStatusError(writer.str());
+        } catch (const tools::error::not_enough_money& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, overall balance only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_not_possible& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount() + e.fee()) %
+                      print_money(e.tx_amount()) %
+                      print_money(e.fee());
+            setStatusError(writer.str());
+        } catch (const tools::error::not_enough_outs_to_mix& e) {
+            std::ostringstream writer;
+            writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
+            for (const std::pair<uint64_t, uint64_t> outs_for_amount : e.scanty_outs()) {
+                writer << "\n" << tr("output amount") << " = " << print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
+            }
+            writer << "\n" << tr("Please sweep unmixable outputs.");
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_not_constructed&) {
+            setStatusError(tr("transaction was not constructed"));
+        } catch (const tools::error::tx_rejected& e) {
+            std::ostringstream writer;
+            writer << (boost::format(tr("transaction %s was rejected by daemon with status: ")) % get_transaction_hash(e.tx())) << e.status();
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_sum_overflow& e) {
+            setStatusError(e.what());
+        } catch (const tools::error::zero_destination&) {
+            setStatusError(tr("one of destinations is zero"));
+        } catch (const tools::error::tx_too_big&) {
+            setStatusError(tr("failed to find a suitable way to split transactions"));
+        } catch (const tools::error::transfer_error& e) {
+            setStatusError(std::string(tr("unknown transfer error: ")) + e.what());
+        } catch (const tools::error::wallet_internal_error& e) {
+            setStatusError(std::string(tr("internal error: ")) + e.what());
+        } catch (const std::exception& e) {
+            setStatusError(std::string(tr("unexpected error: ")) + e.what());
+        } catch (...) {
+            setStatusError(tr("unknown error"));
+        }
+    } while (false);
+
+    transaction->m_status = status();
+    startRefresh();
+    return transaction;
+}
+
+EXPORT
+PendingTransaction *WalletImpl::emitAssetTransaction(const std::string& asset_id, uint64_t amount, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+{
+    clearStatus();
+    pauseRefresh();
+
+    PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
+
+    do {
+        crypto::asset_id parsed_asset_id = crypto::null_aid;
+        if (!tools::hex_to_type(asset_id, parsed_asset_id) || parsed_asset_id == crypto::null_aid) {
+            setStatusError(tr("Invalid asset id"));
+            break;
+        }
+
+        if (amount == 0) {
+            setStatusError(tr("amount must be greater than zero"));
+            break;
+        }
+
+        auto w = wallet();
+        std::vector<cryptonote::tx_destination_entry> dsts;
+        cryptonote::tx_destination_entry dst;
+        dst.amount = amount;
+        dst.addr = w->get_account().get_keys().m_account_address;
+        dst.is_subaddress = false;
+        dst.asset_id = parsed_asset_id;
+        dsts.push_back(dst);
+
+        cryptonote::tx_extra_asset_descriptor_operation ado{};
+        ado.operation_type = cryptonote::asset_descriptor_operation_type::emit_asset;
+        ado.fields = static_cast<uint8_t>(cryptonote::asset_field_asset_id | cryptonote::asset_field_amount);
+        ado.asset_id = parsed_asset_id;
+        ado.amount = amount;
+
+        std::vector<uint8_t> extra;
+        if (!cryptonote::add_asset_descriptor_operation_to_tx_extra(extra, ado)) {
+            setStatusError(tr("Failed to encode asset descriptor into tx extra"));
+            break;
+        }
+
+        try {
+            transaction->m_pending_tx = w->create_asset_emit_tx(
+                    dsts,
+                    parsed_asset_id,
+                    cryptonote::TX_OUTPUT_DECOYS,
+                    priority,
+                    extra,
+                    subaddr_account,
+                    subaddr_indices);
+            pendingTxPostProcess(transaction);
+
+            if (multisig().isMultisig) {
+                auto tx_set = w->make_multisig_tx_set(transaction->m_pending_tx);
+                transaction->m_pending_tx = tx_set.m_ptx;
+                transaction->m_signers = tx_set.m_signers;
+            }
+        } catch (const tools::error::daemon_busy&) {
+            setStatusError(tr("daemon is busy. Please try again later."));
+        } catch (const tools::error::no_connection_to_daemon&) {
+            setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        } catch (const tools::error::wallet_rpc_error& e) {
+            setStatusError(tr("RPC error: ") + e.to_string());
+        } catch (const tools::error::get_outs_error &e) {
+            setStatusError((boost::format(tr("failed to get outputs to mix: %s")) % e.what()).str());
+        } catch (const tools::error::not_enough_unlocked_money& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            setStatusError(writer.str());
+        } catch (const tools::error::not_enough_money& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, overall balance only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_not_possible& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount() + e.fee()) %
+                      print_money(e.tx_amount()) %
+                      print_money(e.fee());
+            setStatusError(writer.str());
+        } catch (const tools::error::not_enough_outs_to_mix& e) {
+            std::ostringstream writer;
+            writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
+            for (const std::pair<uint64_t, uint64_t> outs_for_amount : e.scanty_outs()) {
+                writer << "\n" << tr("output amount") << " = " << print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
+            }
+            writer << "\n" << tr("Please sweep unmixable outputs.");
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_not_constructed&) {
+            setStatusError(tr("transaction was not constructed"));
+        } catch (const tools::error::tx_rejected& e) {
+            std::ostringstream writer;
+            writer << (boost::format(tr("transaction %s was rejected by daemon with status: ")) % get_transaction_hash(e.tx())) << e.status();
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_sum_overflow& e) {
+            setStatusError(e.what());
+        } catch (const tools::error::zero_destination&) {
+            setStatusError(tr("one of destinations is zero"));
+        } catch (const tools::error::tx_too_big&) {
+            setStatusError(tr("failed to find a suitable way to split transactions"));
+        } catch (const tools::error::transfer_error& e) {
+            setStatusError(std::string(tr("unknown transfer error: ")) + e.what());
+        } catch (const tools::error::wallet_internal_error& e) {
+            setStatusError(std::string(tr("internal error: ")) + e.what());
+        } catch (const std::exception& e) {
+            setStatusError(std::string(tr("unexpected error: ")) + e.what());
+        } catch (...) {
+            setStatusError(tr("unknown error"));
+        }
+    } while (false);
+
+    transaction->m_status = status();
+    startRefresh();
+    return transaction;
+}
+
+EXPORT
+PendingTransaction *WalletImpl::burnAssetTransaction(const std::string& asset_id, uint64_t amount, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+{
+    clearStatus();
+    pauseRefresh();
+
+    PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
+
+    do {
+        crypto::asset_id parsed_asset_id = crypto::null_aid;
+        if (!tools::hex_to_type(asset_id, parsed_asset_id) || parsed_asset_id == crypto::null_aid) {
+            setStatusError(tr("Invalid asset id"));
+            break;
+        }
+
+        if (amount == 0) {
+            setStatusError(tr("amount must be greater than zero"));
+            break;
+        }
+
+        std::vector<uint8_t> extra;
+        cryptonote::tx_extra_asset_descriptor_operation ado{};
+        ado.operation_type = cryptonote::asset_descriptor_operation_type::burn_asset;
+        ado.fields = static_cast<uint8_t>(cryptonote::asset_field_asset_id |
+                                          cryptonote::asset_field_amount);
+        ado.asset_id = parsed_asset_id;
+        ado.amount = amount;
+
+        if (!cryptonote::add_asset_descriptor_operation_to_tx_extra(extra, ado)) {
+            setStatusError(tr("Failed to encode asset burn operation into tx extra"));
+            break;
+        }
+
+        auto w = wallet();
+        try {
+            transaction->m_pending_tx = w->create_asset_burn_tx(
+                    parsed_asset_id,
+                    amount,
+                    cryptonote::TX_OUTPUT_DECOYS,
+                    priority,
+                    extra,
+                    subaddr_account,
+                    subaddr_indices);
+            pendingTxPostProcess(transaction);
+
+            if (multisig().isMultisig) {
+                auto tx_set = w->make_multisig_tx_set(transaction->m_pending_tx);
+                transaction->m_pending_tx = tx_set.m_ptx;
+                transaction->m_signers = tx_set.m_signers;
+            }
+        } catch (const tools::error::daemon_busy&) {
+            setStatusError(tr("daemon is busy. Please try again later."));
+        } catch (const tools::error::no_connection_to_daemon&) {
+            setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        } catch (const tools::error::wallet_rpc_error& e) {
+            setStatusError(tr("RPC error: ") + e.to_string());
+        } catch (const tools::error::get_outs_error &e) {
+            setStatusError((boost::format(tr("failed to get outputs to mix: %s")) % e.what()).str());
+        } catch (const tools::error::not_enough_unlocked_money& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            setStatusError(writer.str());
+        } catch (const tools::error::not_enough_money& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, overall balance only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_not_possible& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount() + e.fee()) %
+                      print_money(e.tx_amount()) %
+                      print_money(e.fee());
+            setStatusError(writer.str());
+        } catch (const tools::error::not_enough_outs_to_mix& e) {
+            std::ostringstream writer;
+            writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
+            for (const std::pair<uint64_t, uint64_t> outs_for_amount : e.scanty_outs()) {
+                writer << "\n" << tr("output amount") << " = " << print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
+            }
+            writer << "\n" << tr("Please sweep unmixable outputs.");
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_not_constructed&) {
+            setStatusError(tr("transaction was not constructed"));
+        } catch (const tools::error::tx_rejected& e) {
+            std::ostringstream writer;
+            writer << (boost::format(tr("transaction %s was rejected by daemon with status: ")) % get_transaction_hash(e.tx())) << e.status();
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_sum_overflow& e) {
+            setStatusError(e.what());
+        } catch (const tools::error::zero_destination&) {
+            setStatusError(tr("one of destinations is zero"));
+        } catch (const tools::error::tx_too_big&) {
+            setStatusError(tr("failed to find a suitable way to split transactions"));
+        } catch (const tools::error::transfer_error& e) {
+            setStatusError(std::string(tr("unknown transfer error: ")) + e.what());
+        } catch (const tools::error::wallet_internal_error& e) {
+            setStatusError(std::string(tr("internal error: ")) + e.what());
+        } catch (const std::exception& e) {
+            setStatusError(std::string(tr("unexpected error: ")) + e.what());
+        } catch (...) {
+            setStatusError(tr("unknown error"));
+        }
+    } while (false);
+
+    transaction->m_status = status();
+    startRefresh();
+    return transaction;
+}
+
+EXPORT
+PendingTransaction *WalletImpl::updateAssetTransaction(const std::string& asset_id, const std::string& descriptor_json, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+{
+    clearStatus();
+    pauseRefresh();
+
+    PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
+
+    do {
+        if (subaddr_account != 0 || !subaddr_indices.empty()) {
+            setStatusError(tr("update_asset must be issued from the primary account without subaddress switches"));
+            break;
+        }
+
+        crypto::asset_id parsed_asset_id = crypto::null_aid;
+        if (!tools::hex_to_type(asset_id, parsed_asset_id) || parsed_asset_id == crypto::null_aid) {
+            setStatusError(tr("Invalid asset id"));
+            break;
+        }
+
+        if (descriptor_json.empty()) {
+            setStatusError(tr("descriptor_json is required"));
+            break;
+        }
+
+        auto w = wallet();
+        nlohmann::json info_req = nlohmann::json::object();
+        info_req["asset_id"] = asset_id;
+
+        nlohmann::json info_res;
+        try {
+            info_res = w->json_rpc("get_asset_info", info_req);
+        } catch (const std::exception& e) {
+            setStatusError(tr("Failed to fetch asset info from daemon: ") + std::string(e.what()));
+            break;
+        }
+
+        const std::string requested_owner = tools::type_to_hex(
+                w->get_account().get_keys().m_account_address.m_spend_public_key);
+        if (!info_res.contains("owner") || info_res["owner"].get<std::string>() != requested_owner) {
+            setStatusError(tr("This wallet does not own the asset: ") + asset_id);
+            break;
+        }
+
+        cryptonote::asset_descriptor_base adb{};
+        adb.version = info_res.value("version", 1);
+        adb.total_max_supply = info_res.value("total_max_supply", (uint64_t)0);
+        adb.current_supply = info_res.value("current_supply", (uint64_t)0);
+        adb.decimal_point = info_res.value("decimal_point", 0);
+        adb.ticker = info_res.value("ticker", "");
+        adb.full_name = info_res.value("full_name", "");
+        adb.meta_info = info_res.value("meta_info", "");
+        tools::hex_to_type(info_res.value("owner", ""), adb.owner);
+
+        cryptonote::asset_descriptor_base json_adb = adb;
+        std::string error;
+        if (!load_asset_descriptor_from_json(descriptor_json, json_adb, error)) {
+            setStatusError(tr("Invalid asset descriptor JSON: ") + error);
+            break;
+        }
+
+        if (json_adb.meta_info == adb.meta_info && json_adb.owner == adb.owner) {
+            setStatusError(tr("update_asset: meta_info and owner are unchanged, nothing to update"));
+            break;
+        }
+        adb.meta_info = json_adb.meta_info;
+        if (json_adb.owner != crypto::null_pkey) {
+            adb.owner = json_adb.owner;
+        }
+
+        cryptonote::tx_extra_asset_descriptor_operation ado{};
+        ado.operation_type = cryptonote::asset_descriptor_operation_type::update_asset;
+        ado.fields = static_cast<uint8_t>(cryptonote::asset_field_descriptor |
+                                          cryptonote::asset_field_asset_id);
+        ado.descriptor = adb;
+        ado.asset_id = parsed_asset_id;
+
+        std::vector<uint8_t> extra;
+        if (!cryptonote::add_asset_descriptor_operation_to_tx_extra(extra, ado)) {
+            setStatusError(tr("Failed to encode asset descriptor into tx extra"));
+            break;
+        }
+
+        try {
+            transaction->m_pending_tx = w->create_asset_update_tx(
+                    parsed_asset_id,
+                    cryptonote::TX_OUTPUT_DECOYS,
+                    priority,
+                    extra,
+                    subaddr_account,
+                    subaddr_indices);
+            pendingTxPostProcess(transaction);
+
+            if (multisig().isMultisig) {
+                auto tx_set = w->make_multisig_tx_set(transaction->m_pending_tx);
+                transaction->m_pending_tx = tx_set.m_ptx;
+                transaction->m_signers = tx_set.m_signers;
+            }
+        } catch (const tools::error::daemon_busy&) {
+            setStatusError(tr("daemon is busy. Please try again later."));
+        } catch (const tools::error::no_connection_to_daemon&) {
+            setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        } catch (const tools::error::wallet_rpc_error& e) {
+            setStatusError(tr("RPC error: ") + e.to_string());
+        } catch (const tools::error::get_outs_error &e) {
+            setStatusError((boost::format(tr("failed to get outputs to mix: %s")) % e.what()).str());
+        } catch (const tools::error::not_enough_unlocked_money& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            setStatusError(writer.str());
+        } catch (const tools::error::not_enough_money& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, overall balance only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_not_possible& e) {
+            std::ostringstream writer;
+            writer << boost::format(tr("not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount() + e.fee()) %
+                      print_money(e.tx_amount()) %
+                      print_money(e.fee());
+            setStatusError(writer.str());
+        } catch (const tools::error::not_enough_outs_to_mix& e) {
+            std::ostringstream writer;
+            writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
+            for (const std::pair<uint64_t, uint64_t> outs_for_amount : e.scanty_outs()) {
+                writer << "\n" << tr("output amount") << " = " << print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
+            }
+            writer << "\n" << tr("Please sweep unmixable outputs.");
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_not_constructed&) {
+            setStatusError(tr("transaction was not constructed"));
+        } catch (const tools::error::tx_rejected& e) {
+            std::ostringstream writer;
+            writer << (boost::format(tr("transaction %s was rejected by daemon with status: ")) % get_transaction_hash(e.tx())) << e.status();
+            setStatusError(writer.str());
+        } catch (const tools::error::tx_sum_overflow& e) {
+            setStatusError(e.what());
+        } catch (const tools::error::zero_destination&) {
+            setStatusError(tr("one of destinations is zero"));
+        } catch (const tools::error::tx_too_big&) {
+            setStatusError(tr("failed to find a suitable way to split transactions"));
+        } catch (const tools::error::transfer_error& e) {
+            setStatusError(std::string(tr("unknown transfer error: ")) + e.what());
+        } catch (const tools::error::wallet_internal_error& e) {
+            setStatusError(std::string(tr("internal error: ")) + e.what());
+        } catch (const std::exception& e) {
+            setStatusError(std::string(tr("unexpected error: ")) + e.what());
+        } catch (...) {
+            setStatusError(tr("unknown error"));
+        }
+    } while (false);
+
+    transaction->m_status = status();
     startRefresh();
     return transaction;
 }
@@ -2781,7 +3556,8 @@ bool WalletImpl::checkReserveProof(const std::string &address, const std::string
     try
     {
         clearStatus();
-        good = wallet()->check_reserve_proof(info.address, message, signature, total, spent);
+        std::map<crypto::asset_id, std::pair<uint64_t, uint64_t>> asset_totals;
+        good = wallet()->check_reserve_proof(info.address, message, signature, total, spent, asset_totals);
         return true;
     }
     catch (const std::exception &e)

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -117,6 +117,7 @@ public:
     void setTrustedDaemon(bool arg) override;
     bool trustedDaemon() const override;
     uint64_t balance(uint32_t accountIndex = 0) const override;
+    std::vector<AssetBalanceInfo> assetBalances(uint32_t accountIndex = 0) const override;
     uint64_t unlockedBalance(uint32_t accountIndex = 0) const override;
     int countBns() override;
     std::vector<stakeInfo>* listCurrentStakes() const override;
@@ -173,15 +174,39 @@ public:
 
     PendingTransaction* createTransactionMultDest(const std::vector<std::string> &dst_addr,
                                         std::optional<std::vector<uint64_t>> amount,
+                                        std::optional<std::string> asset_id = std::nullopt,
                                         uint32_t priority = 0,
                                         uint32_t subaddr_account = 0,
                                         std::set<uint32_t> subaddr_indices = {}) override;
     PendingTransaction* createTransaction(const std::string &dst_addr,
                                         std::optional<uint64_t> amount,
+                                        std::optional<std::string> asset_id = std::nullopt,
                                         uint32_t priority = 0,
                                         uint32_t subaddr_account = 0,
                                         std::set<uint32_t> subaddr_indices = {}) override;
-    PendingTransaction* createSweepAllTransaction(uint32_t priority = 0,
+    PendingTransaction* createSweepAllTransaction(std::optional<std::string> asset_id = std::nullopt,
+                                        std::optional<std::string> dst_addr = std::nullopt,
+                                        uint32_t priority = 0,
+                                        uint32_t subaddr_account = 0,
+                                        std::set<uint32_t> subaddr_indices = {}) override;
+    PendingTransaction* deployNewAssetTransaction(const std::string& descriptor_json,
+                                        std::string& asset_id,
+                                        uint32_t priority = 0,
+                                        uint32_t subaddr_account = 0,
+                                        std::set<uint32_t> subaddr_indices = {}) override;
+    PendingTransaction* emitAssetTransaction(const std::string& asset_id,
+                                        uint64_t amount,
+                                        uint32_t priority = 0,
+                                        uint32_t subaddr_account = 0,
+                                        std::set<uint32_t> subaddr_indices = {}) override;
+    PendingTransaction* burnAssetTransaction(const std::string& asset_id,
+                                        uint64_t amount,
+                                        uint32_t priority = 0,
+                                        uint32_t subaddr_account = 0,
+                                        std::set<uint32_t> subaddr_indices = {}) override;
+    PendingTransaction* updateAssetTransaction(const std::string& asset_id,
+                                        const std::string& descriptor_json,
+                                        uint32_t priority = 0,
                                         uint32_t subaddr_account = 0,
                                         std::set<uint32_t> subaddr_indices = {}) override;
     PendingTransaction* createBnsTransaction(std::string& owner,

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -320,6 +320,15 @@ struct MultisigState {
     uint32_t total;
 };
 
+struct AssetBalanceInfo
+{
+    std::string assetId;
+    std::string ticker;
+    uint64_t balance = 0;
+    uint64_t unlockedBalance = 0;
+    uint8_t decimalPoint = 0;
+};
+
 
 struct DeviceProgress {
     DeviceProgress(): m_progress(0), m_indeterminate(false) {}
@@ -615,6 +624,7 @@ struct Wallet
     virtual void setTrustedDaemon(bool arg) = 0;
     virtual bool trustedDaemon() const = 0;
     virtual uint64_t balance(uint32_t accountIndex = 0) const = 0;
+    virtual std::vector<AssetBalanceInfo> assetBalances(uint32_t accountIndex = 0) const = 0;
     uint64_t balanceAll() const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
@@ -862,6 +872,7 @@ struct Wallet
 
     virtual PendingTransaction* createTransactionMultDest(const std::vector<std::string> &dst_addr,
                                                    std::optional<std::vector<uint64_t>> amount,
+                                                   std::optional<std::string> asset_id = std::nullopt,
                                                    uint32_t priority = 0,
                                                    uint32_t subaddr_account = 0,
                                                    std::set<uint32_t> subaddr_indices = {}) = 0;
@@ -878,20 +889,90 @@ struct Wallet
      */
     virtual PendingTransaction *createTransaction(const std::string &dst_addr,
                                                   std::optional<uint64_t> amount,
+                                                  std::optional<std::string> asset_id = std::nullopt,
                                                   uint32_t priority                  = 0,
                                                   uint32_t subaddr_account           = 0,
                                                   std::set<uint32_t> subaddr_indices = {}) = 0;
     /*!
      * \brief createSweepAllTransaction creates transaction for self
+     * \param asset_id          optional sweep mode selector:
+     *                          - omitted/nullopt: sweep native BDX and all assets
+     *                          - "BDX"/"native"/"": sweep native BDX only
+     *                          - asset hex id: sweep that asset only
+     * \param dst_addr          optional destination address:
+     *                          - omitted/nullopt: sweep back to the source wallet primary address
+     *                          - set: sweep to the provided destination wallet address
      * \param subaddr_account   subaddress account from which the input funds are taken
      * \param subaddr_indices   set of subaddress indices to use for transfer or sweeping. if set empty, all are chosen when sweeping, and one or more are automatically chosen when transferring. after execution, returns the set of actually used indices
      * \param priority          set a priority for the transaction. Accepted Values are: default (0), or 0-5 for: default, unimportant, normal, elevated, priority, flash.
      * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                          after object returned
      */
-    virtual PendingTransaction* createSweepAllTransaction(uint32_t priority = 0,
+    virtual PendingTransaction* createSweepAllTransaction(std::optional<std::string> asset_id = std::nullopt,
+                                                    std::optional<std::string> dst_addr = std::nullopt,
+                                                    uint32_t priority = 0,
                                                     uint32_t subaddr_account = 0,
                                                     std::set<uint32_t> subaddr_indices = {}) = 0;
+    /*!
+     * \brief deployNewAssetTransaction creates a deploy_new_asset transaction from a descriptor json string
+     * \param descriptor_json   serialized asset descriptor json
+     * \param asset_id          computed asset id for the deployment request
+     * \param subaddr_account   subaddress account from which native fee inputs are taken
+     * \param subaddr_indices   set of subaddress indices to use
+     * \param priority          set a priority for the transaction. Accepted Values are: default (0), or 0-5 for: default, unimportant, normal, elevated, priority, flash.
+     * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
+     *                          after object returned
+     */
+    virtual PendingTransaction* deployNewAssetTransaction(const std::string& descriptor_json,
+                                                    std::string& asset_id,
+                                                    uint32_t priority = 0,
+                                                    uint32_t subaddr_account = 0,
+                                                    std::set<uint32_t> subaddr_indices = {}) = 0;
+    /*!
+     * \brief emitAssetTransaction creates an emit_asset transaction for an existing asset
+     * \param asset_id          existing asset id hex string
+     * \param amount            amount to emit
+     * \param subaddr_account   subaddress account from which native fee inputs are taken
+     * \param subaddr_indices   set of subaddress indices to use
+     * \param priority          set a priority for the transaction. Accepted Values are: default (0), or 0-5 for: default, unimportant, normal, elevated, priority, flash.
+     * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
+     *                          after object returned
+     */
+    virtual PendingTransaction* emitAssetTransaction(const std::string& asset_id,
+                                                    uint64_t amount,
+                                                    uint32_t priority = 0,
+                                                    uint32_t subaddr_account = 0,
+                                                    std::set<uint32_t> subaddr_indices = {}) = 0;
+    /*!
+     * \brief burnAssetTransaction creates a burn_asset transaction for an existing asset
+     * \param asset_id          existing asset id hex string
+     * \param amount            amount to burn
+     * \param subaddr_account   subaddress account from which inputs are taken
+     * \param subaddr_indices   set of subaddress indices to use
+     * \param priority          set a priority for the transaction. Accepted Values are: default (0), or 0-5 for: default, unimportant, normal, elevated, priority, flash.
+     * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
+     *                          after object returned
+     */
+    virtual PendingTransaction* burnAssetTransaction(const std::string& asset_id,
+                                                    uint64_t amount,
+                                                    uint32_t priority = 0,
+                                                    uint32_t subaddr_account = 0,
+                                                    std::set<uint32_t> subaddr_indices = {}) = 0;
+    /*!
+     * \brief updateAssetTransaction creates an update_asset transaction for an existing asset
+     * \param asset_id          existing asset id hex string
+     * \param descriptor_json   serialized asset descriptor json; meta_info is applied and owner may be changed
+     * \param subaddr_account   subaddress account from which native fee inputs are taken
+     * \param subaddr_indices   set of subaddress indices to use
+     * \param priority          set a priority for the transaction. Accepted Values are: default (0), or 0-5 for: default, unimportant, normal, elevated, priority, flash.
+     * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
+     *                          after object returned
+     */
+    virtual PendingTransaction* updateAssetTransaction(const std::string& asset_id,
+                                                      const std::string& descriptor_json,
+                                                      uint32_t priority = 0,
+                                                      uint32_t subaddr_account = 0,
+                                                      std::set<uint32_t> subaddr_indices = {}) = 0;
 
     /*!
      * \brief createBnsTransaction  creates bns transaction

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10827,6 +10827,24 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
     LOG_PRINT_L2("Adding asset change output for asset " << asset_id << ": " << print_money(change_amount));
   }
 
+  if (tx_params.tx_type == txtype::burn_asset && splitted_dsts.size() < 2)
+  {
+    // HF17+ requires at least 2 outputs for transfer-like txs. Asset burns can
+    // legitimately end up with only a single native change output, so append a
+    // zero-value dummy native output to preserve the burn semantics while
+    // satisfying the minimum output count.
+    cryptonote::account_base dummy;
+    dummy.generate();
+
+    cryptonote::tx_destination_entry dummy_dts{};
+    dummy_dts.addr = dummy.get_keys().m_account_address;
+    dummy_dts.amount = 0;
+    dummy_dts.is_subaddress = false;
+
+    splitted_dsts.push_back(dummy_dts);
+    LOG_PRINT_L2("Added dummy native output for burn_asset to satisfy the HF17 two-output minimum");
+  }
+
   crypto::secret_key tx_key;
   std::vector<crypto::secret_key> additional_tx_keys;
   rct::multisig_out msout;
@@ -12053,7 +12071,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   // early out if we know we can't make it anyway
   // we could also check for being within FEE_PER_KB, but if the fee calculation
   // ever changes, this might be missed, so let this go through
-  const uint64_t min_outputs = (tx_params.tx_type == cryptonote::txtype::beldex_name_system || tx_params.tx_type == cryptonote::txtype::coin_burn || tx_params.tx_type == cryptonote::txtype::burn_asset || tx_params.tx_type == cryptonote::txtype::update_asset) ? 1 : 2; // if bns/burn/update, only request the change output
+  const uint64_t min_outputs = (tx_params.tx_type == cryptonote::txtype::beldex_name_system || tx_params.tx_type == cryptonote::txtype::coin_burn || tx_params.tx_type == cryptonote::txtype::update_asset) ? 1 : 2; // BNS/coin_burn/update can stay single-output; burn_asset must satisfy the HF17 2-output minimum
   {
     uint64_t min_fee = (
         base_fee.first * estimate_rct_tx_size(1, fake_outs_count, min_outputs, extra.size(), clsag, bulletproof_plus) +

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -57,16 +57,16 @@ namespace
 
 // TODO: get rid of hardcoded paths
 
-const char * WALLET_NAME = "testwallet";
+const char * WALLET_NAME = "wallet2";
 const char * WALLET_NAME_MAINNET = "testwallet_mainnet";
 const char * WALLET_NAME_COPY = "testwallet_copy";
-const char * WALLET_NAME_WITH_DIR = "walletdir/testwallet_test";
+const char * WALLET_NAME_WITH_DIR = "build/bin";
 const char * WALLET_NAME_WITH_DIR_NON_WRITABLE = "/var/walletdir/testwallet_test";
-const char * WALLET_PASS = "password";
-const char * WALLET_PASS2 = "password22";
+const char * WALLET_PASS = "";
+const char * WALLET_PASS2 = "";
 const char * WALLET_LANG = "English";
 
-std::string WALLETS_ROOT_DIR = "/var/monero/testnet_pvt";
+std::string WALLETS_ROOT_DIR = "/root/sowjanya/beldex-v2/build/bin";
 std::string TESTNET_WALLET1_NAME;
 std::string TESTNET_WALLET2_NAME;
 std::string TESTNET_WALLET3_NAME;
@@ -76,8 +76,18 @@ std::string TESTNET_WALLET6_NAME;
 
 const char * TESTNET_WALLET_PASS = "";
 
-std::string CURRENT_SRC_WALLET;
-std::string CURRENT_DST_WALLET;
+std::string CURRENT_SRC_WALLET = "/root/sowjanya/beldex-v2/build/bin/wallet2";
+std::string CURRENT_DST_WALLET = "/root/sowjanya/beldex-v2/build/bin/sow";
+std::string TEST_ASSET_ID = "4da3b27f77bc3317299aa4bb852d17e53d11ee8366310c26bd6936ce6043d2cf";
+uint64_t TEST_ASSET_AMOUNT = 1000000;
+std::string TEST_DEPLOY_TICKER = "";
+std::string TEST_DEPLOY_FULL_NAME= "";
+uint64_t TEST_DEPLOY_TOTAL_MAX_SUPPLY = 1000000000;
+uint64_t TEST_DEPLOY_CURRENT_SUPPLY = 1000000000;
+uint64_t TEST_DEPLOY_DECIMAL_POINT = 8;
+std::string TEST_DEPLOY_META_INFO = "libwallet api deploy test";
+std::string TEST_UPDATE_META_INFO = "libwallet api updating info test";
+std::string TEST_UPDATE_OWNER = "9yTHseWEqTnb1ZCNmv36zHYdQqfmHdnjm3WfKoDrTVRgYqqjdNdNn1Ujk4uxriHZLYENzmuEhkyakE4gaQiSnwXhCNfABoz";
 
 const uint64_t AMOUNT_4BDX  =  4000000000L;
 const uint64_t AMOUNT_2BDX  =  2000000000L;
@@ -86,7 +96,7 @@ const uint64_t AMOUNT_1BDX  =  1000000000L;
 
 const std::string PAYMENT_ID_EMPTY = "";
 
-std::string TESTNET_DAEMON_ADDRESS = "38.242.196.72:19091";
+std::string TESTNET_DAEMON_ADDRESS = "127.0.0.1:38081";
 std::string MAINNET_DAEMON_ADDRESS = "explorer.beldex.io:19091";
 
 
@@ -137,6 +147,45 @@ struct Utils
         std::string result = w->mainAddress();
         wmgr->closeWallet(w);
         return result;
+    }
+
+    static std::string first_pending_outgoing_tx(Wallet::Wallet *wallet)
+    {
+        Wallet::TransactionHistory *history = wallet->history();
+        history->refresh();
+        for (auto *tx : history->getAll()) {
+            if (tx != nullptr &&
+                tx->direction() == Wallet::TransactionInfo::Direction_Out &&
+                tx->isPending()) {
+                return tx->hash();
+            }
+        }
+        return {};
+    }
+
+    static bool close_wallet_quietly(Wallet::WalletManagerBase *wmgr, Wallet::Wallet *wallet)
+    {
+        if (wallet) {
+            wallet->pauseRefresh();
+        }
+        return wmgr->closeWallet(wallet);
+    }
+
+    static bool wallet_refresh_ready(Wallet::Wallet *wallet, const std::string &daemon_address, std::string &reason)
+    {
+        if (!wallet->refresh()) {
+            reason = "refresh failed against daemon " + daemon_address + ": " + wallet->status().second;
+            return false;
+        }
+        if (wallet->connected() != Wallet::Wallet::ConnectionStatus_Connected) {
+            reason = "wallet is not connected to daemon " + daemon_address;
+            return false;
+        }
+        if (!wallet->good()) {
+            reason = "wallet status is not good after refresh: " + wallet->status().second;
+            return false;
+        }
+        return true;
     }
 };
 
@@ -498,18 +547,27 @@ TEST_F(WalletTest1, WalletShowsBalance)
     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet1->balance(0) > 0);
-    ASSERT_TRUE(wallet1->unlockedBalance(0) > 0);
 
     uint64_t balance1 = wallet1->balance(0);
     uint64_t unlockedBalance1 = wallet1->unlockedBalance(0);
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
+    ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
     Wallet::Wallet * wallet2 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
     ASSERT_TRUE(wallet2->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(balance1 == wallet2->balance(0));
     std::cout << "wallet balance: " << wallet2->balance(0) << std::endl;
     ASSERT_TRUE(unlockedBalance1 == wallet2->unlockedBalance(0));
     std::cout << "wallet unlocked balance: " << wallet2->unlockedBalance(0) << std::endl;
-    ASSERT_TRUE(wmgr->closeWallet(wallet2));
+    const auto asset_balances = wallet2->assetBalances(0);
+    std::cout << "Confidential asset balances:" << std::endl;
+    for (const auto& asset : asset_balances) {
+        std::cout << "  " << asset.assetId
+                  << " (" << (asset.ticker.empty() ? "unknown" : asset.ticker) << ")"
+                  << "  balance: " << cryptonote::print_asset_amount(asset.balance, asset.decimalPoint, false)
+                  << ", unlocked balance: " << cryptonote::print_asset_amount(asset.unlockedBalance, asset.decimalPoint, false)
+                  << " [dp=" << static_cast<int>(asset.decimalPoint) << "]"
+                  << std::endl;
+    }
+    ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet2));
 }
 
 // TEST_F(WalletTest1, WalletReturnsCurrentBlockHeight)
@@ -546,8 +604,11 @@ TEST_F(WalletTest1, WalletRefresh)
     // make sure testnet daemon is running
     std::cout << "connecting to daemon: " << TESTNET_DAEMON_ADDRESS << std::endl;
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    ASSERT_TRUE(wallet1->refresh());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
+    std::string readiness_error;
+    if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+        GTEST_SKIP() << readiness_error;
+    }
+    ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
 }
 
 // TEST_F(WalletTest1, WalletConvertsToString)
@@ -568,22 +629,33 @@ TEST_F(WalletTest1, WalletRefresh)
 
 // {
 //     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     std::cout << "Opening wallet: " << CURRENT_SRC_WALLET << std::endl;
 //     // make sure testnet daemon is running
 //     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
 //     std::cout <<"Refresh_started...\n";
 //     ASSERT_TRUE(wallet1->refresh());
 //     std::cout <<"Refresh_end...\n";
 //     uint64_t balance = wallet1->balance(0);
+//     uint64_t unlocked_balance = wallet1->unlockedBalance(0);
 //     std::cout <<"**balance: " << balance << std::endl;
+//     std::cout <<"**unlocked balance: " << unlocked_balance << std::endl;
 //     ASSERT_TRUE(wallet1->good());
+
+//     if (unlocked_balance < AMOUNT_4BDX) {
+//         GTEST_SKIP() << "Need at least " << AMOUNT_4BDX
+//                      << " unlocked atomic units to run WalletTransaction, but only "
+//                      << unlocked_balance << " are unlocked.";
+//     }
 
 //     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
 //     const int MIXIN_COUNT = 4;
+//     std::cout<<"destination wallet"<< CURRENT_DST_WALLET << std::endl;
+//     std::cout<<"recepient_address"<< recepient_address << std::endl;
 
 
 //     Wallet::PendingTransaction * transaction = wallet1->createTransaction(recepient_address,
 //                                                                              AMOUNT_4BDX);
-//     ASSERT_TRUE(transaction->good());
+//     ASSERT_TRUE(transaction->good()) << transaction->status().second;
 //     std::cout <<"refresh_started...\n";
 //     wallet1->refresh();
 //     std::cout <<"refresh_end...\n";
@@ -594,450 +666,849 @@ TEST_F(WalletTest1, WalletRefresh)
 //     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 // }
 
-TEST_F(WalletTest1, BnsBuyTransaction)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+// TEST_F(WalletTest1, WalletAssetTransaction)
 
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
+// {
+//     if (TEST_ASSET_ID.empty()) {
+//         GTEST_SKIP() << "Set TEST_ASSET_ID to validate asset createTransaction().";
+//     }
 
-    // Change the value based on your datas
-    std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
-    std::string backup_owner = "";
-    std::string mapping_years = "1y";
-    std::string value_bchat = "";
-    std::string value_wallet = "";
-    std::string value_belnet = "a6iiyy3c4qsp8kdt49ao79dqxskd81eejidhq9j36d8oodznibqy.bdx";
-    std::string value_eth_addr = "";
-    std::string name  ="blackpearl.bdx";
-    Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
-                                                                                backup_owner,
-                                                                                mapping_years,
-                                                                                value_bchat,
-                                                                                value_wallet,
-                                                                                value_belnet,
-                                                                                value_eth_addr,
-                                                                                name);
-    ASSERT_TRUE(transaction->good());
-    std::cout <<"refresh_started...\n";
-    wallet1->refresh();
-    std::cout <<"refresh_end...\n";
-    ASSERT_TRUE(wallet1->balance(0) == balance);
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     ASSERT_TRUE(wallet1->refresh());
+//     ASSERT_TRUE(wallet1->good());
+//     uint64_t balance_before = wallet1->balance(0);
+//     uint64_t unlocked_before = wallet1->unlockedBalance(0);
+//     std::cout << "**source balance before asset send: " << balance_before << std::endl;
+//     std::cout << "**source unlocked before asset send: " << unlocked_before << std::endl;
 
-    ASSERT_TRUE(transaction->commit());
-    ASSERT_FALSE(wallet1->balance(0) == balance);
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
+//     Wallet::TransactionHistory * pre_history = wallet1->history();
+//     pre_history->refresh();
+//     for (auto *tx : pre_history->getAll()) {
+//         if (tx != nullptr &&
+//             tx->direction() == Wallet::TransactionInfo::Direction_Out &&
+//             tx->isPending()) {
+//             GTEST_SKIP() << "Wallet already has a pending outgoing transaction in history/txpool: "
+//                          << tx->hash();
+//         }
+//     }
 
-TEST_F(WalletTest1, BnsBuyEthTransaction)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
+//     std::cout << "destination wallet" << CURRENT_DST_WALLET << std::endl;
+//     std::cout << "recepient_address" << recepient_address << std::endl;
+//     std::cout << "asset_id " << TEST_ASSET_ID << ", amount " << TEST_ASSET_AMOUNT << std::endl;
+//     Wallet::PendingTransaction * transaction = wallet1->createTransaction(recepient_address,
+//                                                                              TEST_ASSET_AMOUNT,
+//                                                                              TEST_ASSET_ID);
+//     ASSERT_TRUE(transaction->good()) << transaction->status().second;
+//     ASSERT_TRUE(transaction->amount() == TEST_ASSET_AMOUNT);
+//     std::vector<std::string> txids = transaction->txid();
+//     ASSERT_FALSE(txids.empty());
+//     if (!transaction->commit()) {
+//         const std::string commit_error = transaction->status().second;
+//         if (commit_error.find("Double spend") != std::string::npos ||
+//             commit_error.find("double spend") != std::string::npos) {
+//             GTEST_SKIP() << "Asset output is already locked by a pending tx in the daemon txpool: "
+//                          << commit_error;
+//         }
+//         FAIL() << commit_error;
+//     }
 
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
+//     ASSERT_TRUE(wallet1->refresh());
+//     uint64_t balance_after = wallet1->balance(0);
+//     uint64_t unlocked_after = wallet1->unlockedBalance(0);
+//     std::cout << "**source balance after asset send: " << balance_after << std::endl;
+//     std::cout << "**source unlocked after asset send: " << unlocked_after << std::endl;
+//     ASSERT_TRUE(balance_after < balance_before);
 
-    // Change the value based on your datas
-    std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
-    std::string backup_owner = "";
-    std::string mapping_years = "1y";
-    std::string value_bchat = "";
-    std::string value_wallet = "";
-    std::string value_belnet = "a6iiyy3c4qsp8kdt49ao79dqxskd81eejidhq9j36d8oodznibqy.bdx";
-    std::string value_eth_addr = "0xbBdA8c587De8dC04Abb35de738C04E4413355007";
-    std::string name  ="toretto.bdx";
-    Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
-                                                                                backup_owner,
-                                                                                mapping_years,
-                                                                                value_bchat,
-                                                                                value_wallet,
-                                                                                value_belnet,
-                                                                                value_eth_addr,
-                                                                                name);
-    ASSERT_TRUE(transaction->good());
-    std::cout <<"refresh_started...\n";
-    wallet1->refresh();
-    std::cout <<"refresh_end...\n";
-    ASSERT_TRUE(wallet1->balance(0) == balance);
+//     Wallet::TransactionHistory * history = wallet1->history();
+//     history->refresh();
+//     Wallet::TransactionInfo * sent_tx = history->transaction(txids.front());
+//     ASSERT_TRUE(sent_tx != nullptr);
+//     ASSERT_TRUE(sent_tx->direction() == Wallet::TransactionInfo::Direction_Out);
+//     ASSERT_TRUE(sent_tx->amount() == TEST_ASSET_AMOUNT);
+//     ASSERT_TRUE(!sent_tx->transfers().empty());
+//     ASSERT_TRUE(sent_tx->transfers().front().address == recepient_address);
+//     ASSERT_TRUE(sent_tx->transfers().front().amount == TEST_ASSET_AMOUNT);
 
-    ASSERT_TRUE(transaction->commit());
-    ASSERT_FALSE(wallet1->balance(0) == balance);
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
 
-TEST_F(WalletTest1, BnsBuyTransactionWithNoValues)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
+// TEST_F(WalletTest1, WalletSweepAllTransaction)
 
-    // Change the value based on your datas
-    std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
-    std::string backup_owner = "";
-    std::string mapping_years = "10y";
-    std::string value_bchat = "";
-    std::string value_wallet = "";
-    std::string value_belnet = "";
-    std::string value_eth_addr = "";    
-    std::string name  ="black.bdx";
-    Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
-                                                                                backup_owner,
-                                                                                mapping_years,
-                                                                                value_bchat,
-                                                                                value_wallet,
-                                                                                value_belnet,
-                                                                                value_eth_addr,
-                                                                                name);
-    Utils::print_status(transaction->status());
-    ASSERT_FALSE(transaction->good());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
+// {
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::string readiness_error;
+//     if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+//         GTEST_SKIP() << readiness_error;
+//     }
+//     if (wallet1->unlockedBalance(0) == 0) {
+//         GTEST_SKIP() << "Sweep-all needs unlocked native BDX to build and pay fees.";
+//     }
+//     const std::string pending_tx = Utils::first_pending_outgoing_tx(wallet1);
+//     if (!pending_tx.empty()) {
+//         GTEST_SKIP() << "Wallet already has a pending outgoing transaction in history/txpool: "
+//                      << pending_tx;
+//     }
+//     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
+//     std::cout << "destination wallet" << CURRENT_DST_WALLET << std::endl;
+//     std::cout << "recepient_address" << recepient_address << std::endl;
 
-TEST_F(WalletTest1, BnsBuyTransactionWithWrongYears)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
+//     Wallet::PendingTransaction * transaction = wallet1->createSweepAllTransaction(std::nullopt, recepient_address);
+//     ASSERT_TRUE(transaction->good()) << transaction->status().second;
+//     ASSERT_TRUE(transaction->txCount() > 0);
+//     if (!transaction->commit()) {
+//         const std::string commit_error = transaction->status().second;
+//         if (commit_error.find("Double spend") != std::string::npos ||
+//             commit_error.find("double spend") != std::string::npos) {
+//             GTEST_SKIP() << "Sweep transaction is blocked by a pending tx in the daemon txpool: "
+//                          << commit_error;
+//         }
+//         FAIL() << commit_error;
+//     }
+//     ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
+// }
 
-    // Change the value based on your datas
-    std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
-    std::string backup_owner = "";
-    std::string mapping_years = "6y";
-    std::string value_bchat = "";
-    std::string value_wallet = "";
-    std::string value_belnet = "t9e3s4k9rw4e6fxexycb74wo1guriebnsepfkkfr6s3rpxauncmy.bdx";
-    std::string value_eth_addr = "";
-    std::string name  ="black.bdx";
-    Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
-                                                                                backup_owner,
-                                                                                mapping_years,
-                                                                                value_bchat,
-                                                                                value_wallet,
-                                                                                value_belnet,
-                                                                                value_eth_addr,
-                                                                                name);
-    Utils::print_status(transaction->status());
-    ASSERT_FALSE(transaction->good());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
+// TEST_F(WalletTest1, WalletNativeSweepAllTransaction)
 
-TEST_F(WalletTest1, BnsBuyTransactionWithOldValue)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
+// {
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::string readiness_error;
+//     if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+//         GTEST_SKIP() << readiness_error;
+//     }
+//     if (wallet1->unlockedBalance(0) == 0) {
+//         GTEST_SKIP() << "Native sweep needs unlocked native BDX.";
+//     }
+//     const std::string pending_tx = Utils::first_pending_outgoing_tx(wallet1);
+//     if (!pending_tx.empty()) {
+//         GTEST_SKIP() << "Wallet already has a pending outgoing transaction in history/txpool: "
+//                      << pending_tx;
+//     }
+//     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
+//     std::cout << "destination wallet" << CURRENT_DST_WALLET << std::endl;
+//     std::cout << "recepient_address" << recepient_address << std::endl;
 
-    // Change the value based on your datas
-    std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
-    std::string backup_owner = "";
-    std::string mapping_years = "1y";
-    std::string value_bchat = "";
-    std::string value_wallet = "";
-    std::string value_belnet = "a6iiyy3c4qsp8kdt49ao79dqxskd81eejidhq9j36d8oodznibqy.bdx";
-    std::string value_eth_addr = "";
-    std::string name  ="blackpearl.bdx";
-    Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
-                                                                                backup_owner,
-                                                                                mapping_years,
-                                                                                value_bchat,
-                                                                                value_wallet,
-                                                                                value_belnet,
-                                                                                value_eth_addr,
-                                                                                name);
-    ASSERT_TRUE(transaction->good());
-    std::cout <<"refresh_started...\n";
-    wallet1->refresh();
-    std::cout <<"refresh_end...\n";
-    ASSERT_TRUE(wallet1->balance(0) == balance);
-    ASSERT_FALSE(transaction->commit());
-    Utils::print_status(transaction->status());
-    ASSERT_FALSE(transaction->good());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
+//     Wallet::PendingTransaction * transaction = wallet1->createSweepAllTransaction("BDX", recepient_address);
+//     ASSERT_TRUE(transaction->good()) << transaction->status().second;
+//     ASSERT_TRUE(transaction->txCount() > 0);
+//     if (!transaction->commit()) {
+//         const std::string commit_error = transaction->status().second;
+//         if (commit_error.find("Double spend") != std::string::npos ||
+//             commit_error.find("double spend") != std::string::npos) {
+//             GTEST_SKIP() << "Native sweep transaction is blocked by a pending tx in the daemon txpool: "
+//                          << commit_error;
+//         }
+//         FAIL() << commit_error;
+//     }
+//     ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
+// }
 
-TEST_F(WalletTest1, BnsUpdateTransaction)
+// TEST_F(WalletTest1, WalletAssetSweepAllTransaction)
 
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
+// {
+//     if (TEST_ASSET_ID.empty()) {
+//         GTEST_SKIP() << "Set TEST_ASSET_ID to validate asset createSweepAllTransaction().";
+//     }
 
-    // Change the value based on your datas
-    std::string owner = "";
-    std::string backup_owner = "";
-    std::string value_bchat = "bd08c9d0c3077a509f159a2d91aa251b69480a3572f2ce60f01f01067b06de9c21";
-    std::string value_wallet = "";
-    std::string value_belnet = "";
-    std::string value_eth_addr = "";
-    std::string name  ="blackpearl.bdx";
-    Wallet::PendingTransaction *transaction = wallet1->bnsUpdateTransaction(owner, backup_owner, value_bchat, value_wallet, value_belnet, value_eth_addr, name);
-    ASSERT_TRUE(transaction->good());
-    std::cout <<"refresh_started...\n";
-    wallet1->refresh();
-    std::cout <<"refresh_end...\n";
-    ASSERT_TRUE(wallet1->balance(0) == balance);
-    ASSERT_TRUE(transaction->commit());
-    ASSERT_FALSE(wallet1->balance(0) == balance);
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::string readiness_error;
+//     if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+//         GTEST_SKIP() << readiness_error;
+//     }
+//     if (wallet1->unlockedBalance(0) == 0) {
+//         GTEST_SKIP() << "Asset sweep still needs unlocked native BDX to pay the transaction fee.";
+//     }
+//     const std::string pending_tx = Utils::first_pending_outgoing_tx(wallet1);
+//     if (!pending_tx.empty()) {
+//         GTEST_SKIP() << "Wallet already has a pending outgoing transaction in history/txpool: "
+//                      << pending_tx;
+//     }
+//     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
+//     std::cout << "destination wallet" << CURRENT_DST_WALLET << std::endl;
+//     std::cout << "recepient_address" << recepient_address << std::endl;
 
-TEST_F(WalletTest1, BnsEthUpdateTransaction)
+//     Wallet::PendingTransaction * transaction = wallet1->createSweepAllTransaction(TEST_ASSET_ID, recepient_address);
+//     ASSERT_TRUE(transaction->good()) << transaction->status().second;
+//     ASSERT_TRUE(transaction->txCount() > 0);
+//     if (!transaction->commit()) {
+//         const std::string commit_error = transaction->status().second;
+//         if (commit_error.find("Double spend") != std::string::npos ||
+//             commit_error.find("double spend") != std::string::npos) {
+//             GTEST_SKIP() << "Asset sweep transaction is blocked by a pending tx in the daemon txpool: "
+//                          << commit_error;
+//         }
+//         FAIL() << commit_error;
+//     }
+//     ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
+// }
 
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
-
-    // Change the value based on your datas
-    std::string owner = "";
-    std::string backup_owner = "";
-    std::string value_bchat = "bd08c9d0c3077a509f159a2d91aa251b69480a3572f2ce60f01f01067b06de9c21";
-    std::string value_wallet = "";
-    std::string value_belnet = "";
-    std::string value_eth_addr = "0xa83114A443dA1CecEFC50368531cACE9F37fCCcb";
-    std::string name  ="toretto.bdx";
-    Wallet::PendingTransaction *transaction = wallet1->bnsUpdateTransaction(owner, backup_owner, value_bchat, value_wallet, value_belnet, value_eth_addr, name);
-    ASSERT_TRUE(transaction->good());
-    std::cout <<"refresh_started...\n";
-    wallet1->refresh();
-    std::cout <<"refresh_end...\n";
-    ASSERT_TRUE(wallet1->balance(0) == balance);
-    ASSERT_TRUE(transaction->commit());
-    ASSERT_FALSE(wallet1->balance(0) == balance);
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
-
-TEST_F(WalletTest1, BnsUpdateWithSameValue)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
-
-    // Change the value based on your datas
-    std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
-    std::string backup_owner = "";
-    std::string value_bchat = "bd08c9d0c3077a509f159a2d91aa251b69480a3572f2ce60f01f01067b06de9c21";
-    std::string value_wallet = "";
-    std::string value_belnet = "fcbzchy4kknz1tq8eb5aiakibyfo7nqg6qxpons46h1qytexfc4y.bdx";
-    std::string value_eth_addr = "";
-    std::string name  ="blackpearl.bdx";
-    Wallet::PendingTransaction *transaction = wallet1->bnsUpdateTransaction(owner, backup_owner, value_bchat, value_wallet, value_belnet, value_eth_addr, name);
-    ASSERT_TRUE(transaction->good());
-    std::cout <<"refresh_started...\n";
-    wallet1->refresh();
-    std::cout <<"refresh_end...\n";
-    ASSERT_TRUE(wallet1->balance(0) == balance);
-    ASSERT_FALSE(transaction->commit());
-    Utils::print_status(transaction->status());
-    ASSERT_FALSE(transaction->good());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
-
-TEST_F(WalletTest1, BnsUpdateWrongValues)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
-
-    // Change the value based on your datas
-    std::string owner = "";
-    std::string backup_owner = "";
-    std::string value_bchat ="";
-    std::string value_wallet ="";
-    std::string value_belnet ="bd08c9d0c3077a509f159a2d91aa251b69480a3572f2ce60f01f01067b06de9c21";
-    std::string value_eth_addr = "";
-    std::string name  ="blackpearl.bdx";
-    Wallet::PendingTransaction *transaction = wallet1->bnsUpdateTransaction(owner, backup_owner, value_bchat, value_wallet, value_belnet, value_eth_addr, name);
-    ASSERT_FALSE(transaction->good());
-    Utils::print_status(transaction->status());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
-
-TEST_F(WalletTest1, BnsRenewTransaction)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
-
-    std::string name  ="rohan.bdx";
-    std::string year  ="10y";
-    Wallet::PendingTransaction * transaction = wallet1->bnsRenewTransaction(name,
-                                                                            year);
-    ASSERT_TRUE(transaction->good());
-    std::cout <<"refresh_started...\n";
-    wallet1->refresh();
-    std::cout <<"refresh_end...\n";
-    ASSERT_TRUE(wallet1->balance(0) == balance);
-    Utils::print_status(transaction->status());
-    ASSERT_TRUE(transaction->commit());
-    Utils::print_status(transaction->status());
-    ASSERT_TRUE(transaction->good());
-    ASSERT_FALSE(wallet1->balance(0) == balance);
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
-
-TEST_F(WalletTest1, BnsRenewTransactionForNonExistBns)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
-
-    std::string name  ="roha.bdx";
-    std::string year  ="2y";
-    Wallet::PendingTransaction * transaction = wallet1->bnsRenewTransaction(name,
-                                                                            year);
-    ASSERT_FALSE(transaction->good());
-    Utils::print_status(transaction->status());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
-
-TEST_F(WalletTest1, BnsRenewTransactionForWrongYear)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::cout <<"Refresh_started...\n";
-    ASSERT_TRUE(wallet1->refresh());
-    std::cout <<"Refresh_end...\n";
-    uint64_t balance = wallet1->balance(0);
-    std::cout <<"**balance: " << balance << std::endl;
-    ASSERT_TRUE(wallet1->good());
-
-    std::string name  ="rohan.bdx";
-    std::string year  ="3y";
-    Wallet::PendingTransaction * transaction = wallet1->bnsRenewTransaction(name,
-                                                                            year);
-    ASSERT_FALSE(transaction->good());
-    Utils::print_status(transaction->status());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
-
-
-TEST_F(WalletTest1, countForBns)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
-
-    // make sure testnet daemon is running
-    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-
-    int val = wallet1->countBns();
-    std::cout<<"Bns count is :"<<val<<std::endl;
-
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
-
-TEST_F(WalletTest1, statusOfCountBns)
-{
-    //TODO=Beldex_bns have to check more conditions also the wallet_listener check
-    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);    
-    
-    int val = wallet1->countBns();
-    std::cout<<"Bns count is :"<<val<<std::endl;
-    Utils::print_status(wallet1->status());
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
-}
-
-TEST_F(WalletTest1, bnsByOwner)
+TEST_F(WalletTest1, WalletDeployNewAssetTransaction)
 {
     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    std::vector<Wallet::bnsInfo> data = *(wallet1->MyBns());
 
-    for (const auto& info : data) {
-        std::cout << "name_hash :" << info.name_hash << std::endl;
-        std::cout << "name :" << info.name << std::endl;
-        std::cout << "value_bchat :" << info.value_bchat << std::endl;
-        std::cout << "value_wallet :" << info.value_wallet << std::endl;
-        std::cout << "value_belnet :" << info.value_belnet << std::endl;
-        std::cout << "owner :" << info.owner << std::endl;
-        std::cout << "backup_owner :" << info.backup_owner << std::endl;
-        std::cout << "update_height :" << info.update_height << std::endl;
-        std::cout << "expiration_height :" << info.expiration_height << std::endl;
-        std::cout << "encrypted_bchat_value :" << info.encrypted_bchat_value << std::endl;
-        std::cout << "encrypted_wallet_value :" << info.encrypted_wallet_value << std::endl;
-        std::cout << "encrypted_belnet_value :" << info.encrypted_belnet_value << std::endl;
+    std::string readiness_error;
+    if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+        GTEST_SKIP() << readiness_error;
+    }
+    if (wallet1->unlockedBalance(0) == 0) {
+        GTEST_SKIP() << "Need unlocked native BDX to pay deploy_new_asset fee.";
     }
 
-    ASSERT_TRUE(wmgr->closeWallet(wallet1));
+    const auto unique_suffix = std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count());
+    const std::string short_suffix = unique_suffix.substr(unique_suffix.size() > 6 ? unique_suffix.size() - 6 : 0);
+    const std::string ticker = TEST_DEPLOY_TICKER.empty() ? "T" + short_suffix : TEST_DEPLOY_TICKER;
+    const std::string full_name = TEST_DEPLOY_FULL_NAME.empty() ? "Test Asset " + short_suffix : TEST_DEPLOY_FULL_NAME;
+
+    std::ostringstream descriptor_json;
+    descriptor_json << "{"
+                    << "\"ticker\":\"" << ticker << "\","
+                    << "\"full_name\":\"" << full_name << "\","
+                    << "\"decimal_point\":" << TEST_DEPLOY_DECIMAL_POINT << ","
+                    << "\"total_max_supply\":" << TEST_DEPLOY_TOTAL_MAX_SUPPLY << ","
+                    << "\"current_supply\":" << TEST_DEPLOY_CURRENT_SUPPLY << ","
+                    << "\"meta_info\":\"" << TEST_DEPLOY_META_INFO << "\""
+                    << "}";
+
+    std::cout << "deploy ticker " << ticker
+              << ", full_name " << full_name
+              << ", decimal_point " << TEST_DEPLOY_DECIMAL_POINT
+              << ", total_max_supply " << TEST_DEPLOY_TOTAL_MAX_SUPPLY
+              << ", current_supply " << TEST_DEPLOY_CURRENT_SUPPLY
+              << ", meta_info " << TEST_DEPLOY_META_INFO << std::endl;
+
+    std::string asset_id;
+    Wallet::PendingTransaction * transaction =
+            wallet1->deployNewAssetTransaction(descriptor_json.str(), asset_id);
+
+    ASSERT_TRUE(transaction->good()) << transaction->status().second;
+    ASSERT_FALSE(asset_id.empty());
+    ASSERT_TRUE(transaction->txCount() > 0);
+
+    if (!transaction->commit()) {
+        const std::string commit_error = transaction->status().second;
+        if (commit_error.find("Double spend") != std::string::npos ||
+            commit_error.find("double spend") != std::string::npos) {
+            GTEST_SKIP() << "Asset deploy transaction is blocked by a pending tx in the daemon txpool: "
+                         << commit_error;
+        }
+        FAIL() << commit_error;
+    }
+
+    ASSERT_TRUE(wallet1->refresh());
+    std::cout << "deployed asset_id " << asset_id << ", ticker " << ticker << std::endl;
+    ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
 }
+
+TEST_F(WalletTest1, WalletEmitAssetTransaction)
+{
+    if (TEST_ASSET_ID.empty()) {
+        GTEST_SKIP() << "Set TEST_ASSET_ID to validate emitAssetTransaction().";
+    }
+    if (TEST_ASSET_AMOUNT == 0) {
+        GTEST_SKIP() << "Set TEST_ASSET_AMOUNT to a non-zero value to validate emitAssetTransaction().";
+    }
+
+    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+
+    std::string readiness_error;
+    if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+        GTEST_SKIP() << readiness_error;
+    }
+    if (wallet1->unlockedBalance(0) == 0) {
+        GTEST_SKIP() << "Need unlocked native BDX to pay emit_asset fee.";
+    }
+
+    std::string asset_id = TEST_ASSET_ID;
+    Wallet::PendingTransaction * transaction =
+            wallet1->emitAssetTransaction(asset_id, TEST_ASSET_AMOUNT);
+
+    ASSERT_TRUE(transaction->good()) << transaction->status().second;
+    ASSERT_TRUE(transaction->txCount() > 0);
+
+    if (!transaction->commit()) {
+        const std::string commit_error = transaction->status().second;
+        if (commit_error.find("Double spend") != std::string::npos ||
+            commit_error.find("double spend") != std::string::npos) {
+            GTEST_SKIP() << "Asset emit transaction is blocked by a pending tx in the daemon txpool: "
+                         << commit_error;
+        }
+        FAIL() << commit_error;
+    }
+
+    ASSERT_TRUE(wallet1->refresh());
+    std::cout << "emitted asset_id " << asset_id << ", amount " << TEST_ASSET_AMOUNT << std::endl;
+    ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
+}
+
+// TEST_F(WalletTest1, WalletBurnAssetTransaction)
+// {
+//     if (TEST_ASSET_ID.empty()) {
+//         GTEST_SKIP() << "Set TEST_ASSET_ID to validate burnAssetTransaction().";
+//     }
+//     if (TEST_ASSET_AMOUNT == 0) {
+//         GTEST_SKIP() << "Set TEST_ASSET_AMOUNT to a non-zero value to validate burnAssetTransaction().";
+//     }
+
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+
+//     std::string readiness_error;
+//     if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+//         GTEST_SKIP() << readiness_error;
+//     }
+//     if (wallet1->unlockedBalance(0) == 0) {
+//         GTEST_SKIP() << "Need unlocked native BDX to pay burn_asset fee.";
+//     }
+
+//     const uint64_t native_balance_before = wallet1->balance(0);
+//     const uint64_t native_unlocked_before = wallet1->unlockedBalance(0);
+//     std::cout << "burn asset_id " << TEST_ASSET_ID
+//               << ", amount " << TEST_ASSET_AMOUNT << std::endl;
+//     std::cout << "native balance before burn: " << native_balance_before
+//               << ", unlocked: " << native_unlocked_before << std::endl;
+
+//     Wallet::PendingTransaction * transaction =
+//             wallet1->burnAssetTransaction(TEST_ASSET_ID, TEST_ASSET_AMOUNT);
+
+//     ASSERT_TRUE(transaction->good()) << transaction->status().second;
+//     ASSERT_TRUE(transaction->txCount() > 0);
+//     const std::vector<std::string> txids = transaction->txid();
+//     ASSERT_FALSE(txids.empty());
+//     std::cout << "burn txid " << txids.front() << std::endl;
+
+//     if (!transaction->commit()) {
+//         const std::string commit_error = transaction->status().second;
+//         if (commit_error.find("Double spend") != std::string::npos ||
+//             commit_error.find("double spend") != std::string::npos) {
+//             GTEST_SKIP() << "Asset burn transaction is blocked by a pending tx in the daemon txpool: "
+//                          << commit_error;
+//         }
+//         FAIL() << commit_error;
+//     }
+
+//     ASSERT_TRUE(wallet1->refresh());
+//     const uint64_t native_balance_after = wallet1->balance(0);
+//     const uint64_t native_unlocked_after = wallet1->unlockedBalance(0);
+//     std::cout << "burned asset_id " << TEST_ASSET_ID << ", amount " << TEST_ASSET_AMOUNT << std::endl;
+//     std::cout << "native balance after burn: " << native_balance_after
+//               << ", unlocked: " << native_unlocked_after << std::endl;
+//     ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
+// }
+
+TEST_F(WalletTest1, WalletUpdateAssetTransaction)
+{
+    if (TEST_ASSET_ID.empty()) {
+        GTEST_SKIP() << "Set TEST_ASSET_ID to validate updateAssetTransaction().";
+    }
+    if (TEST_UPDATE_META_INFO.empty()) {
+        GTEST_SKIP() << "Set TEST_UPDATE_META_INFO to validate updateAssetTransaction().";
+    }
+
+    Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+    ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+
+    std::string readiness_error;
+    if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+        GTEST_SKIP() << readiness_error;
+    }
+    if (wallet1->unlockedBalance(0) == 0) {
+        GTEST_SKIP() << "Need unlocked native BDX to pay update_asset fee.";
+    }
+
+    std::ostringstream descriptor_json;
+    descriptor_json << "{"
+                    << "\"ticker\":\"" << TEST_DEPLOY_TICKER << "\","
+                    << "\"full_name\":\"" << TEST_DEPLOY_FULL_NAME << "\","
+                    << "\"decimal_point\":" << TEST_DEPLOY_DECIMAL_POINT << ","
+                    << "\"total_max_supply\":" << TEST_DEPLOY_TOTAL_MAX_SUPPLY << ","
+                    << "\"current_supply\":" << TEST_DEPLOY_CURRENT_SUPPLY << ","
+                    << "\"meta_info\":\"" << TEST_UPDATE_META_INFO << "\"";
+    if (!TEST_UPDATE_OWNER.empty()) {
+        descriptor_json << ",\"owner\":\"" << TEST_UPDATE_OWNER << "\"";
+    }
+    descriptor_json << "}";
+
+    std::cout << "update asset_id " << TEST_ASSET_ID
+              << ", meta_info " << TEST_UPDATE_META_INFO;
+    if (!TEST_UPDATE_OWNER.empty()) {
+        std::cout << ", owner " << TEST_UPDATE_OWNER;
+    }
+    std::cout << std::endl;
+
+    Wallet::PendingTransaction * transaction =
+            wallet1->updateAssetTransaction(TEST_ASSET_ID, descriptor_json.str());
+
+    ASSERT_TRUE(transaction->good()) << transaction->status().second;
+    ASSERT_TRUE(transaction->txCount() > 0);
+    const std::vector<std::string> txids = transaction->txid();
+    ASSERT_FALSE(txids.empty());
+    std::cout << "update txid " << txids.front() << std::endl;
+
+    if (!transaction->commit()) {
+        const std::string commit_error = transaction->status().second;
+        if (commit_error.find("Double spend") != std::string::npos ||
+            commit_error.find("double spend") != std::string::npos) {
+            GTEST_SKIP() << "Asset update transaction is blocked by a pending tx in the daemon txpool: "
+                         << commit_error;
+        }
+        FAIL() << commit_error;
+    }
+
+    ASSERT_TRUE(wallet1->refresh());
+    ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
+}
+
+// TEST_F(WalletTest1, BnsBuyTransaction)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
+//     std::string backup_owner = "";
+//     std::string mapping_years = "1y";
+//     std::string value_bchat = "";
+//     std::string value_wallet = "";
+//     std::string value_belnet = "a6iiyy3c4qsp8kdt49ao79dqxskd81eejidhq9j36d8oodznibqy.bdx";
+//     std::string value_eth_addr = "";
+//     std::string name  ="blackpearl.bdx";
+//     Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
+//                                                                                 backup_owner,
+//                                                                                 mapping_years,
+//                                                                                 value_bchat,
+//                                                                                 value_wallet,
+//                                                                                 value_belnet,
+//                                                                                 value_eth_addr,
+//                                                                                 name);
+//     ASSERT_TRUE(transaction->good());
+//     std::cout <<"refresh_started...\n";
+//     wallet1->refresh();
+//     std::cout <<"refresh_end...\n";
+//     ASSERT_TRUE(wallet1->balance(0) == balance);
+
+//     ASSERT_TRUE(transaction->commit());
+//     ASSERT_FALSE(wallet1->balance(0) == balance);
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsBuyEthTransaction)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
+//     std::string backup_owner = "";
+//     std::string mapping_years = "1y";
+//     std::string value_bchat = "";
+//     std::string value_wallet = "";
+//     std::string value_belnet = "a6iiyy3c4qsp8kdt49ao79dqxskd81eejidhq9j36d8oodznibqy.bdx";
+//     std::string value_eth_addr = "0xbBdA8c587De8dC04Abb35de738C04E4413355007";
+//     std::string name  ="toretto.bdx";
+//     Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
+//                                                                                 backup_owner,
+//                                                                                 mapping_years,
+//                                                                                 value_bchat,
+//                                                                                 value_wallet,
+//                                                                                 value_belnet,
+//                                                                                 value_eth_addr,
+//                                                                                 name);
+//     ASSERT_TRUE(transaction->good());
+//     std::cout <<"refresh_started...\n";
+//     wallet1->refresh();
+//     std::cout <<"refresh_end...\n";
+//     ASSERT_TRUE(wallet1->balance(0) == balance);
+
+//     ASSERT_TRUE(transaction->commit());
+//     ASSERT_FALSE(wallet1->balance(0) == balance);
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsBuyTransactionWithNoValues)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
+//     std::string backup_owner = "";
+//     std::string mapping_years = "10y";
+//     std::string value_bchat = "";
+//     std::string value_wallet = "";
+//     std::string value_belnet = "";
+//     std::string value_eth_addr = "";    
+//     std::string name  ="black.bdx";
+//     Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
+//                                                                                 backup_owner,
+//                                                                                 mapping_years,
+//                                                                                 value_bchat,
+//                                                                                 value_wallet,
+//                                                                                 value_belnet,
+//                                                                                 value_eth_addr,
+//                                                                                 name);
+//     Utils::print_status(transaction->status());
+//     ASSERT_FALSE(transaction->good());
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsBuyTransactionWithWrongYears)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
+//     std::string backup_owner = "";
+//     std::string mapping_years = "6y";
+//     std::string value_bchat = "";
+//     std::string value_wallet = "";
+//     std::string value_belnet = "t9e3s4k9rw4e6fxexycb74wo1guriebnsepfkkfr6s3rpxauncmy.bdx";
+//     std::string value_eth_addr = "";
+//     std::string name  ="black.bdx";
+//     Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
+//                                                                                 backup_owner,
+//                                                                                 mapping_years,
+//                                                                                 value_bchat,
+//                                                                                 value_wallet,
+//                                                                                 value_belnet,
+//                                                                                 value_eth_addr,
+//                                                                                 name);
+//     Utils::print_status(transaction->status());
+//     ASSERT_FALSE(transaction->good());
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsBuyTransactionWithOldValue)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
+//     std::string backup_owner = "";
+//     std::string mapping_years = "1y";
+//     std::string value_bchat = "";
+//     std::string value_wallet = "";
+//     std::string value_belnet = "a6iiyy3c4qsp8kdt49ao79dqxskd81eejidhq9j36d8oodznibqy.bdx";
+//     std::string value_eth_addr = "";
+//     std::string name  ="blackpearl.bdx";
+//     Wallet::PendingTransaction * transaction = wallet1->createBnsTransaction(owner,
+//                                                                                 backup_owner,
+//                                                                                 mapping_years,
+//                                                                                 value_bchat,
+//                                                                                 value_wallet,
+//                                                                                 value_belnet,
+//                                                                                 value_eth_addr,
+//                                                                                 name);
+//     ASSERT_TRUE(transaction->good());
+//     std::cout <<"refresh_started...\n";
+//     wallet1->refresh();
+//     std::cout <<"refresh_end...\n";
+//     ASSERT_TRUE(wallet1->balance(0) == balance);
+//     ASSERT_FALSE(transaction->commit());
+//     Utils::print_status(transaction->status());
+//     ASSERT_FALSE(transaction->good());
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsUpdateTransaction)
+
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = "";
+//     std::string backup_owner = "";
+//     std::string value_bchat = "bd08c9d0c3077a509f159a2d91aa251b69480a3572f2ce60f01f01067b06de9c21";
+//     std::string value_wallet = "";
+//     std::string value_belnet = "";
+//     std::string value_eth_addr = "";
+//     std::string name  ="blackpearl.bdx";
+//     Wallet::PendingTransaction *transaction = wallet1->bnsUpdateTransaction(owner, backup_owner, value_bchat, value_wallet, value_belnet, value_eth_addr, name);
+//     ASSERT_TRUE(transaction->good());
+//     std::cout <<"refresh_started...\n";
+//     wallet1->refresh();
+//     std::cout <<"refresh_end...\n";
+//     ASSERT_TRUE(wallet1->balance(0) == balance);
+//     ASSERT_TRUE(transaction->commit());
+//     ASSERT_FALSE(wallet1->balance(0) == balance);
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsEthUpdateTransaction)
+
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = "";
+//     std::string backup_owner = "";
+//     std::string value_bchat = "bd08c9d0c3077a509f159a2d91aa251b69480a3572f2ce60f01f01067b06de9c21";
+//     std::string value_wallet = "";
+//     std::string value_belnet = "";
+//     std::string value_eth_addr = "0xa83114A443dA1CecEFC50368531cACE9F37fCCcb";
+//     std::string name  ="toretto.bdx";
+//     Wallet::PendingTransaction *transaction = wallet1->bnsUpdateTransaction(owner, backup_owner, value_bchat, value_wallet, value_belnet, value_eth_addr, name);
+//     ASSERT_TRUE(transaction->good());
+//     std::cout <<"refresh_started...\n";
+//     wallet1->refresh();
+//     std::cout <<"refresh_end...\n";
+//     ASSERT_TRUE(wallet1->balance(0) == balance);
+//     ASSERT_TRUE(transaction->commit());
+//     ASSERT_FALSE(wallet1->balance(0) == balance);
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsUpdateWithSameValue)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = Utils::get_wallet_address(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS);
+//     std::string backup_owner = "";
+//     std::string value_bchat = "bd08c9d0c3077a509f159a2d91aa251b69480a3572f2ce60f01f01067b06de9c21";
+//     std::string value_wallet = "";
+//     std::string value_belnet = "fcbzchy4kknz1tq8eb5aiakibyfo7nqg6qxpons46h1qytexfc4y.bdx";
+//     std::string value_eth_addr = "";
+//     std::string name  ="blackpearl.bdx";
+//     Wallet::PendingTransaction *transaction = wallet1->bnsUpdateTransaction(owner, backup_owner, value_bchat, value_wallet, value_belnet, value_eth_addr, name);
+//     ASSERT_TRUE(transaction->good());
+//     std::cout <<"refresh_started...\n";
+//     wallet1->refresh();
+//     std::cout <<"refresh_end...\n";
+//     ASSERT_TRUE(wallet1->balance(0) == balance);
+//     ASSERT_FALSE(transaction->commit());
+//     Utils::print_status(transaction->status());
+//     ASSERT_FALSE(transaction->good());
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsUpdateWrongValues)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     // Change the value based on your datas
+//     std::string owner = "";
+//     std::string backup_owner = "";
+//     std::string value_bchat ="";
+//     std::string value_wallet ="";
+//     std::string value_belnet ="bd08c9d0c3077a509f159a2d91aa251b69480a3572f2ce60f01f01067b06de9c21";
+//     std::string value_eth_addr = "";
+//     std::string name  ="blackpearl.bdx";
+//     Wallet::PendingTransaction *transaction = wallet1->bnsUpdateTransaction(owner, backup_owner, value_bchat, value_wallet, value_belnet, value_eth_addr, name);
+//     ASSERT_FALSE(transaction->good());
+//     Utils::print_status(transaction->status());
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsRenewTransaction)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     std::string name  ="rohan.bdx";
+//     std::string year  ="10y";
+//     Wallet::PendingTransaction * transaction = wallet1->bnsRenewTransaction(name,
+//                                                                             year);
+//     ASSERT_TRUE(transaction->good());
+//     std::cout <<"refresh_started...\n";
+//     wallet1->refresh();
+//     std::cout <<"refresh_end...\n";
+//     ASSERT_TRUE(wallet1->balance(0) == balance);
+//     Utils::print_status(transaction->status());
+//     ASSERT_TRUE(transaction->commit());
+//     Utils::print_status(transaction->status());
+//     ASSERT_TRUE(transaction->good());
+//     ASSERT_FALSE(wallet1->balance(0) == balance);
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsRenewTransactionForNonExistBns)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     std::string name  ="roha.bdx";
+//     std::string year  ="2y";
+//     Wallet::PendingTransaction * transaction = wallet1->bnsRenewTransaction(name,
+//                                                                             year);
+//     ASSERT_FALSE(transaction->good());
+//     Utils::print_status(transaction->status());
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, BnsRenewTransactionForWrongYear)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::cout <<"Refresh_started...\n";
+//     ASSERT_TRUE(wallet1->refresh());
+//     std::cout <<"Refresh_end...\n";
+//     uint64_t balance = wallet1->balance(0);
+//     std::cout <<"**balance: " << balance << std::endl;
+//     ASSERT_TRUE(wallet1->good());
+
+//     std::string name  ="rohan.bdx";
+//     std::string year  ="3y";
+//     Wallet::PendingTransaction * transaction = wallet1->bnsRenewTransaction(name,
+//                                                                             year);
+//     ASSERT_FALSE(transaction->good());
+//     Utils::print_status(transaction->status());
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+//}
+
+
+// TEST_F(WalletTest1, countForBns)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+
+//     // make sure testnet daemon is running
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+
+//     int val = wallet1->countBns();
+//     std::cout<<"Bns count is :"<<val<<std::endl;
+
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, statusOfCountBns)
+// {
+//     //TODO=Beldex_bns have to check more conditions also the wallet_listener check
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);    
+    
+//     int val = wallet1->countBns();
+//     std::cout<<"Bns count is :"<<val<<std::endl;
+//     Utils::print_status(wallet1->status());
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
+
+// TEST_F(WalletTest1, bnsByOwner)
+// {
+//     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
+//     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
+//     std::vector<Wallet::bnsInfo> data = *(wallet1->MyBns());
+
+//     for (const auto& info : data) {
+//         std::cout << "name_hash :" << info.name_hash << std::endl;
+//         std::cout << "name :" << info.name << std::endl;
+//         std::cout << "value_bchat :" << info.value_bchat << std::endl;
+//         std::cout << "value_wallet :" << info.value_wallet << std::endl;
+//         std::cout << "value_belnet :" << info.value_belnet << std::endl;
+//         std::cout << "owner :" << info.owner << std::endl;
+//         std::cout << "backup_owner :" << info.backup_owner << std::endl;
+//         std::cout << "update_height :" << info.update_height << std::endl;
+//         std::cout << "expiration_height :" << info.expiration_height << std::endl;
+//         std::cout << "encrypted_bchat_value :" << info.encrypted_bchat_value << std::endl;
+//         std::cout << "encrypted_wallet_value :" << info.encrypted_wallet_value << std::endl;
+//         std::cout << "encrypted_belnet_value :" << info.encrypted_belnet_value << std::endl;
+//     }
+
+//     ASSERT_TRUE(wmgr->closeWallet(wallet1));
+// }
 
 // TEST_F(WalletTest1, WalletTransactionWithMixin)
 // {
@@ -1125,7 +1596,10 @@ TEST_F(WalletTest1, WalletHistory)
     Wallet::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
-    ASSERT_TRUE(wallet1->refresh());
+    std::string readiness_error;
+    if (!Utils::wallet_refresh_ready(wallet1, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+        GTEST_SKIP() << readiness_error;
+    }
     Wallet::TransactionHistory * history = wallet1->history();
     history->refresh();
     ASSERT_TRUE(history->count() > 0);
@@ -1135,6 +1609,7 @@ TEST_F(WalletTest1, WalletHistory)
         ASSERT_TRUE(t != nullptr);
         Utils::print_transaction(t);
     }
+    ASSERT_TRUE(Utils::close_wallet_quietly(wmgr, wallet1));
 }
 
 // TEST_F(WalletTest1, WalletTransactionAndHistory)
@@ -1320,12 +1795,16 @@ TEST_F(WalletTest2, WalletCallBackRefreshedSync)
     Wallet::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, Wallet::NetworkType::TESTNET);
     MyWalletListener * wallet_src_listener = new MyWalletListener(wallet_src);
     ASSERT_TRUE(wallet_src->init(TESTNET_DAEMON_ADDRESS, 0));
-    ASSERT_TRUE(wallet_src->refresh());
+    std::string readiness_error;
+    if (!Utils::wallet_refresh_ready(wallet_src, TESTNET_DAEMON_ADDRESS, readiness_error)) {
+        GTEST_SKIP() << readiness_error;
+    }
     ASSERT_TRUE(wallet_src_listener->refresh_triggered);
-    ASSERT_TRUE(wallet_src->connected());
     std::unique_lock lock{wallet_src_listener->mutex};
-    wallet_src_listener->cv_refresh.wait_for(lock, 3min);
-    wmgr->closeWallet(wallet_src);
+    ASSERT_TRUE(wallet_src_listener->cv_refresh.wait_for(lock, 5s, [&wallet_src_listener] {
+        return wallet_src_listener->refresh_triggered;
+    }));
+    Utils::close_wallet_quietly(wmgr, wallet_src);
 }
 
 
@@ -1581,16 +2060,69 @@ int main(int argc, char** argv)
         WALLETS_ROOT_DIR = wallets_root_dir;
     }
 
+    const char * test_asset_id = std::getenv("TEST_ASSET_ID");
+    if (test_asset_id) {
+        TEST_ASSET_ID = test_asset_id;
+    }
 
-    TESTNET_WALLET1_NAME = WALLETS_ROOT_DIR + "/wallet_01.bin";
-    TESTNET_WALLET2_NAME = WALLETS_ROOT_DIR + "/wallet_02.bin";
+    const char * test_asset_amount = std::getenv("TEST_ASSET_AMOUNT");
+    if (test_asset_amount) {
+        TEST_ASSET_AMOUNT = std::stoull(test_asset_amount);
+    }
+
+    const char * test_deploy_ticker = std::getenv("TEST_DEPLOY_TICKER");
+    if (test_deploy_ticker) {
+        TEST_DEPLOY_TICKER = test_deploy_ticker;
+    }
+
+    const char * test_deploy_full_name = std::getenv("TEST_DEPLOY_FULL_NAME");
+    if (test_deploy_full_name) {
+        TEST_DEPLOY_FULL_NAME = test_deploy_full_name;
+    }
+
+    const char * test_deploy_total_max_supply = std::getenv("TEST_DEPLOY_TOTAL_MAX_SUPPLY");
+    if (test_deploy_total_max_supply) {
+        TEST_DEPLOY_TOTAL_MAX_SUPPLY = std::stoull(test_deploy_total_max_supply);
+    }
+
+    const char * test_deploy_current_supply = std::getenv("TEST_DEPLOY_CURRENT_SUPPLY");
+    if (test_deploy_current_supply) {
+        TEST_DEPLOY_CURRENT_SUPPLY = std::stoull(test_deploy_current_supply);
+    }
+
+    const char * test_deploy_decimal_point = std::getenv("TEST_DEPLOY_DECIMAL_POINT");
+    if (test_deploy_decimal_point) {
+        TEST_DEPLOY_DECIMAL_POINT = std::stoull(test_deploy_decimal_point);
+    }
+
+    const char * test_deploy_meta_info = std::getenv("TEST_DEPLOY_META_INFO");
+    if (test_deploy_meta_info) {
+        TEST_DEPLOY_META_INFO = test_deploy_meta_info;
+    }
+
+    const char * test_update_meta_info = std::getenv("TEST_UPDATE_META_INFO");
+    if (test_update_meta_info) {
+        TEST_UPDATE_META_INFO = test_update_meta_info;
+    }
+
+    const char * test_update_owner = std::getenv("TEST_UPDATE_OWNER");
+    if (test_update_owner) {
+        TEST_UPDATE_OWNER = test_update_owner;
+    }
+
+    const char * current_src_wallet = std::getenv("CURRENT_SRC_WALLET");
+    const char * current_dst_wallet = std::getenv("CURRENT_DST_WALLET");
+
+
+    TESTNET_WALLET1_NAME = WALLETS_ROOT_DIR + "/wallet2";
+    TESTNET_WALLET2_NAME = WALLETS_ROOT_DIR + "/sow";
     TESTNET_WALLET3_NAME = WALLETS_ROOT_DIR + "/wallet_03.bin";
     TESTNET_WALLET4_NAME = WALLETS_ROOT_DIR + "/wallet_04.bin";
     TESTNET_WALLET5_NAME = WALLETS_ROOT_DIR + "/wallet_05.bin";
     TESTNET_WALLET6_NAME = WALLETS_ROOT_DIR + "/wallet_06.bin";
 
-    CURRENT_SRC_WALLET = TESTNET_WALLET5_NAME;
-    CURRENT_DST_WALLET = TESTNET_WALLET1_NAME;
+    CURRENT_SRC_WALLET = current_src_wallet ? current_src_wallet : WALLETS_ROOT_DIR + "/wallet2";
+    CURRENT_DST_WALLET = current_dst_wallet ? current_dst_wallet : TESTNET_WALLET2_NAME;
 
     ::testing::InitGoogleTest(&argc, argv);
     Wallet::WalletManagerFactory::setLogLevel(Wallet::WalletManagerFactory::LogLevel_Max);


### PR DESCRIPTION
- Extend Wallet API transfer to support asset transfers
- Extend Wallet API sweepAll to support asset sweeping
- Add libwallet API tests for:
  - deploy_new_asset
  - emit_asset
  - burn_asset
  - update_asset