### PR TITLE
Feature: Implement confidential asset burn fees

### DIFF
--- a/src/beldex_economy.h
+++ b/src/beldex_economy.h
@@ -148,3 +148,24 @@ constexpr uint64_t burn_needed(cryptonote::hf hf_version, mapping_years map_year
 }
 }; // namespace bns
 
+namespace cryptonote { enum class asset_descriptor_operation_type : uint8_t; }
+
+namespace assets
+{
+constexpr uint64_t burn_needed(cryptonote::hf hf_version, cryptonote::asset_descriptor_operation_type op_type)
+{
+  uint64_t basic_fee = 100 * beldex::COIN; 
+
+  switch (static_cast<uint8_t>(op_type))
+  {
+    case 1: // register_asset (deploy_new_asset)
+      return basic_fee * 2; // Higher fee (e.g. 200 BDX)
+    case 2: // emit_asset
+      return basic_fee / 2;  // Slightly low (e.g. 50 BDX)
+    case 3: // update_asset
+      return basic_fee / 10; // Very low fee (e.g. 10 BDX)
+    default:
+      return 0;
+  }
+}
+}; // namespace assets

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3913,6 +3913,29 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         return false;
       }
     }
+    else if (tx.type == txtype::deploy_new_asset || tx.type == txtype::emit_asset || tx.type == txtype::update_asset)
+    {
+      cryptonote::tx_extra_asset_descriptor_operation op;
+      size_t skip = 0;
+      uint64_t total_burn_required = 0;
+      while (cryptonote::get_asset_descriptor_operation_from_tx_extra(tx.extra, op, skip++)) {
+        total_burn_required += assets::burn_needed(hf_version, op.operation_type);
+      }
+      
+      if (total_burn_required > 0)
+      {
+        const uint64_t burn = cryptonote::get_burned_amount_from_tx_extra(tx.extra);
+        const uint64_t fee  = tx.rct_signatures.txnFee;
+
+        if (burn < total_burn_required || burn > fee)
+        {
+          tvc.m_verbose_error = "Asset transaction requires burning " + std::to_string(total_burn_required) + 
+                                " but burned " + std::to_string(burn) + " (fee: " + std::to_string(fee) + ")";
+          MERROR_VER("Failed to validate Asset TX reason: " << tvc.m_verbose_error);
+          return false;
+        }
+      }
+    }
   }
   }
   else

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -9668,7 +9668,8 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
     uint64_t received;
     bool in_pool = false;
     uint64_t confirmations;
-    m_wallet->check_tx_key(txid, tx_key, additional_tx_keys, info.address, received, in_pool, confirmations);
+    std::map<crypto::asset_id, uint64_t> asset_received;
+    m_wallet->check_tx_key(txid, tx_key, additional_tx_keys, info.address, received, in_pool, confirmations, asset_received);
 
     if (received > 0)
     {
@@ -9740,7 +9741,8 @@ bool simple_wallet::check_tx_proof(const std::vector<std::string> &args)
     uint64_t received;
     bool in_pool = false;
     uint64_t confirmations;
-    if (m_wallet->check_tx_proof(txid, info.address, info.is_subaddress, args.size() == 4 ? args[3] : "", sig_str, received, in_pool, confirmations))
+    std::map<crypto::asset_id, uint64_t> asset_received;
+    if (m_wallet->check_tx_proof(txid, info.address, info.is_subaddress, args.size() == 4 ? args[3] : "", sig_str, received, in_pool, confirmations, asset_received))
     {
       success_msg_writer(true) << tr("Good signature");
       if (received > 0)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11727,7 +11727,7 @@ std::vector<wallet2::pending_tx> wallet2::create_asset_deploy_tx(
   THROW_WALLET_EXCEPTION_IF(!hf_ver, error::wallet_internal_error,
       "Failed to get hard fork version from daemon");
   beldex_construct_tx_params tx_params = wallet2::construct_params(
-      *hf_ver, txtype::deploy_new_asset, priority);
+      *hf_ver, txtype::deploy_new_asset, priority, assets::burn_needed(*hf_ver, cryptonote::asset_descriptor_operation_type::register_asset));
 
   return create_transactions_2(dsts, fake_outs_count, 0 /*unlock_time*/,
                                priority, extra, subaddr_account,
@@ -11748,7 +11748,7 @@ std::vector<wallet2::pending_tx> wallet2::create_asset_emit_tx(
   THROW_WALLET_EXCEPTION_IF(!hf_ver, error::wallet_internal_error,
       "Failed to get hard fork version from daemon");
   beldex_construct_tx_params tx_params = wallet2::construct_params(
-      *hf_ver, txtype::emit_asset, priority);
+      *hf_ver, txtype::emit_asset, priority, assets::burn_needed(*hf_ver, cryptonote::asset_descriptor_operation_type::emit_asset));
 
   return create_transactions_2(dsts, fake_outs_count, 0 /*unlock_time*/,
                                priority, extra, subaddr_account,
@@ -11767,7 +11767,7 @@ std::vector<wallet2::pending_tx> wallet2::create_asset_update_tx(
   THROW_WALLET_EXCEPTION_IF(!hf_ver, error::wallet_internal_error,
       "Failed to get hard fork version from daemon");
   beldex_construct_tx_params tx_params = wallet2::construct_params(
-      *hf_ver, txtype::update_asset, priority);
+      *hf_ver, txtype::update_asset, priority, assets::burn_needed(*hf_ver, cryptonote::asset_descriptor_operation_type::update_asset));
 
   std::vector<cryptonote::tx_destination_entry> dsts; // Update tx typically doesn't transfer funds
   return create_transactions_2(dsts, fake_outs_count, 0 /*unlock_time*/,

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2287,8 +2287,16 @@ namespace tools
     cryptonote::address_parse_info info;
     if(!get_account_address_from_str(info, m_wallet->nettype(), req.address))
       throw wallet_rpc_error{error_code::WRONG_ADDRESS, "Invalid address"};
+    std::map<crypto::asset_id, uint64_t> asset_received;
 
-    m_wallet->check_tx_key(txid, tx_key, additional_tx_keys, info.address, res.received, res.in_pool, res.confirmations);
+    m_wallet->check_tx_key(txid, tx_key, additional_tx_keys, info.address, res.received, res.in_pool, res.confirmations, asset_received);
+    for (const auto& [aid, amount] : asset_received)
+    {
+      wallet_rpc::asset_received_entry entry;
+      entry.asset_id = tools::type_to_hex(aid);
+      entry.amount = amount;
+      res.asset_received.push_back(entry);
+    }
     return res;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -2323,7 +2331,15 @@ namespace tools
       throw wallet_rpc_error{error_code::WRONG_ADDRESS, "Invalid address"};
 
     {
-      res.good = m_wallet->check_tx_proof(txid, info.address, info.is_subaddress, req.message, req.signature, res.received, res.in_pool, res.confirmations);
+      std::map<crypto::asset_id, uint64_t> asset_received;
+      res.good = m_wallet->check_tx_proof(txid, info.address, info.is_subaddress, req.message, req.signature, res.received, res.in_pool, res.confirmations, asset_received);
+      for (const auto& [aid, amount] : asset_received)
+      {
+        wallet_rpc::asset_received_entry entry;
+        entry.asset_id = tools::type_to_hex(aid);
+        entry.amount = amount;
+        res.asset_received.push_back(entry);
+      }
     }
     return res;
   }


### PR DESCRIPTION
* Defined assets::burn_needed() in beldex_economy.h to enforce required native BDX burn fees for asset operations (deploy: 200 BDX, emit: 50 BDX, update: 10 BDX).
* Updated simplewallet.cpp and wallet_rpc_server.cpp to properly support the new check_tx_key and check_tx_proof function signatures.
* Extended CHECK_TX_KEY and CHECK_TX_PROOF RPC endpoints to accurately populate and return asset_received balances from the wallet to the caller.