### PR TITLE
feat(gateway): implement gateway ownership update dual-signature prot…

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -62,6 +62,7 @@ inline constexpr uint64_t PUBLIC_ADDRESS_TEXTBLOB_VER          = 0;
 // TX_EXTRA_TAG_BURN machinery. 100 BDX (COIN = 10^9 atomic units). Spelled as a
 // literal here because beldex_economy.h (which defines COIN) includes this file.
 inline constexpr uint64_t GATEWAY_ADDRESS_REGISTRATION_FEE     = UINT64_C(100000000000); // 100 * pow(10, 9)
+inline constexpr uint64_t GATEWAY_ADDRESS_UPDATE_FEE           = UINT64_C(10000000000);  // 10 * pow(10, 9)
 
 // Max length (bytes) of a gateway descriptor's meta_info string. The descriptor
 // is persisted append-only into the consensus DB and an update tx pays only a

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -814,7 +814,7 @@ namespace cryptonote
       proofs.emplace_back(gateway_input_sig{owner_sig});
     tx.gateway_proofs = std::move(proofs);
     tx.invalidate_hashes();
-    return true;
+        return true;
   }
   //---------------------------------------------------------------
   bool sign_gateway_register_tx(network_type nettype, transaction& tx,
@@ -844,6 +844,133 @@ namespace cryptonote
       if (!std::holds_alternative<gateway_ownership_proof>(p))
         proofs.push_back(p);
     proofs.emplace_back(gateway_ownership_proof{gateway_owner_sig_v{sig}});
+    tx.gateway_proofs = std::move(proofs);
+    tx.invalidate_hashes();
+    return true;
+  }
+  //---------------------------------------------------------------
+  // Gateway descriptor update (HF22). See the header for the two-signature
+  // rationale. Self-funded and output-less, so it is a pure-gateway tx:
+  // verify_pure_gateway_balance computes fee = Σin − Σout = the input amount.
+  bool construct_gateway_update_tx(hf hf_version,
+                                   network_type nettype,
+                                   const crypto::public_key& gateway_id,
+                                   const gateway_owner_key_v& new_owner_key,
+                                   const std::string& meta_info,
+                                   uint64_t fee,
+                                   transaction& tx,
+                                   crypto::hash& hash_to_sign_input,
+                                   crypto::hash& hash_to_sign_ownership)
+  {
+    tx.set_null();
+    tx.version     = transaction::get_max_version_for_hf(hf_version);
+    tx.type        = txtype::update_gateway_address;
+    tx.unlock_time = 0;
+
+    if (fee == 0)
+    {
+      LOG_ERROR("gateway update: fee must be > 0 (it is the tx's only input amount)");
+      return false;
+    }
+    // Fail here rather than let consensus reject it later with a vaguer reason.
+    if (!is_valid_gateway_owner_key(new_owner_key))
+    {
+      LOG_ERROR("gateway update: invalid new owner key for its type");
+      return false;
+    }
+    if (meta_info.size() > GATEWAY_DESCRIPTOR_MAX_META_INFO_SIZE)
+    {
+      LOG_ERROR("gateway update: meta_info exceeds " << GATEWAY_DESCRIPTOR_MAX_META_INFO_SIZE << " bytes");
+      return false;
+    }
+
+    // The descriptor operation carries the NEW owner key / meta.
+    tx_extra_gateway_descriptor_operation op{};
+    op.version              = 0;
+    op.op_type              = gateway_descriptor_op_type::update_address;
+    op.address_id           = gateway_id;
+    op.descriptor.version   = 0;
+    op.descriptor.owner_key = new_owner_key;
+    op.descriptor.meta_info = meta_info;
+    if (!add_gateway_descriptor_operation_to_tx_extra(tx.extra, op))
+    {
+      LOG_ERROR("gateway update: failed to serialize descriptor operation");
+      return false;
+    }
+    if (!add_burned_amount_to_tx_extra(tx.extra, GATEWAY_ADDRESS_UPDATE_FEE))
+    {
+      LOG_ERROR("gateway update: failed to serialize burn amount to tx extra");
+      return false;
+    }
+
+    // Single gateway input funding the fee; no outputs (update txs are exempt
+    // from the minimum-output-count rule).
+    txin_gateway in{};
+    in.version      = 0;
+    in.gateway_addr = gateway_id;
+    in.asset_id     = crypto::null_aid; // HF22: native BDX
+    in.amount       = GATEWAY_ADDRESS_UPDATE_FEE + fee;
+    tx.vin.emplace_back(in);
+
+    // Pure-gateway tx: no RCT data.
+    tx.rct_signatures      = {};
+    tx.rct_signatures.type = rct::RCTType::Null;
+
+    // Canonical proof layout consensus expects for a descriptor tx with one
+    // gateway input: [ownership_proof][input_sig]. Empty slots; the owner fills them.
+    tx.gateway_proofs.clear();
+    tx.gateway_proofs.emplace_back(gateway_ownership_proof{});
+    tx.gateway_proofs.emplace_back(gateway_input_sig{});
+
+    tx.invalidate_hashes();
+    // Both messages hash the tx PREFIX, which the (prunable) proof slots are not
+    // part of, so filling them later does not change either hash.
+    hash_to_sign_input     = gateway_input_message(nettype, tx);
+    hash_to_sign_ownership = gateway_ownership_message(nettype, tx);
+    return true;
+  }
+  //---------------------------------------------------------------
+  bool finalize_gateway_update_tx(network_type nettype,
+                                  transaction& tx,
+                                  const gateway_owner_key_v& current_owner_key,
+                                  const gateway_owner_sig_v& input_sig,
+                                  const gateway_owner_sig_v& ownership_sig)
+  {
+    if (tx.type != txtype::update_gateway_address)
+    {
+      LOG_ERROR("gateway update finalize: tx type is not update_gateway_address");
+      return false;
+    }
+    if (!tx.has_gateway_inputs())
+    {
+      LOG_ERROR("gateway update finalize: tx has no gateway inputs");
+      return false;
+    }
+
+    // Verify each signature against its OWN domain-separated message; a sig valid
+    // for one must not be accepted for the other.
+    if (!verify_gateway_owner_signature(current_owner_key, input_sig, gateway_input_message(nettype, tx)))
+    {
+      LOG_ERROR("gateway update finalize: input signature does not verify");
+      return false;
+    }
+    if (!verify_gateway_owner_signature(current_owner_key, ownership_sig, gateway_ownership_message(nettype, tx)))
+    {
+      LOG_ERROR("gateway update finalize: ownership proof does not verify");
+      return false;
+    }
+
+    size_t gw_inputs = 0;
+    for (const auto& vin : tx.vin)
+      if (std::holds_alternative<txin_gateway>(vin))
+        ++gw_inputs;
+
+    // Rewrite in canonical order: [ownership_proof][input_sig × gw_inputs].
+    std::vector<gateway_proof_v> proofs;
+    proofs.reserve(1 + gw_inputs);
+    proofs.emplace_back(gateway_ownership_proof{ownership_sig});
+    for (size_t i = 0; i < gw_inputs; ++i)
+      proofs.emplace_back(gateway_input_sig{input_sig});
     tx.gateway_proofs = std::move(proofs);
     tx.invalidate_hashes();
     return true;

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -287,6 +287,38 @@ namespace cryptonote
   // (vin/vout/extra) is final. Returns false on a type/key mismatch.
   bool sign_gateway_register_tx(network_type nettype, transaction& tx,
                                 const crypto::secret_key& gateway_skey);
+
+  // Build an UNSIGNED gateway descriptor update (HF22): replaces a gateway's
+  // owner key and/or meta_info. Self-funded — a single txin_gateway spends `fee`
+  // from the gateway's OWN balance and the tx has no outputs (update txs are
+  // exempt from the min-2-outputs rule), so the daemon can build it with no
+  // wallet and no keys. Being a pure-gateway tx it carries no RCT data and is
+  // balance-checked arithmetically (fee == Σin − Σout).
+  //
+  // Requires TWO signatures, both from the CURRENT owner key (the new owner key
+  // only takes effect once this tx is applied), over domain-separated messages:
+  //   hash_to_sign_input     = H(GW_INPUT_SIG || genesis || prefix)  -> authorizes spending the fee
+  //   hash_to_sign_ownership = H(GW_OWNERSHIP || genesis || prefix)  -> authorizes the descriptor change
+  // Attach both via finalize_gateway_update_tx (same nettype).
+  bool construct_gateway_update_tx(hf hf_version,
+                                   network_type nettype,
+                                   const crypto::public_key& gateway_id,
+                                   const gateway_owner_key_v& new_owner_key,
+                                   const std::string& meta_info,
+                                   uint64_t fee,
+                                   transaction& tx,
+                                   crypto::hash& hash_to_sign_input,
+                                   crypto::hash& hash_to_sign_ownership);
+
+  // Attach both current-owner signatures to an update built above (verifies each
+  // against its own message first). nettype must match construct_gateway_update_tx.
+  // Writes the canonical proof layout consensus expects: [ownership][input_sig].
+  bool finalize_gateway_update_tx(network_type nettype,
+                                  transaction& tx,
+                                  const gateway_owner_key_v& current_owner_key,
+                                  const gateway_owner_sig_v& input_sig,
+                                  const gateway_owner_sig_v& ownership_sig);
+
   struct gateway_wallet_destination
   {
     account_public_address addr; // main address only (v1: no subaddresses)

--- a/src/cryptonote_core/gateway_utils.cpp
+++ b/src/cryptonote_core/gateway_utils.cpp
@@ -575,6 +575,13 @@ bool validate_gateway_descriptor_operation(BlockchainDB& db, network_type nettyp
         return false;
       }
 
+      if (acct.latest_descriptor().owner_key == op.descriptor.owner_key &&
+          acct.latest_descriptor().meta_info == op.descriptor.meta_info)
+      {
+        reason = "update descriptor is identical to current descriptor";
+        return false;
+      }
+
       const gateway_ownership_proof* proof = nullptr;
       for (const auto& p : tx.gateway_proofs)
       {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3830,6 +3830,51 @@ namespace cryptonote::rpc {
   }
 
   //------------------------------------------------------------------------------------------------------------------------------
+  namespace {
+    // Parse a hex signature into the variant alternative matching `owner_key`'s
+    // type. `what` names the field for error messages.
+    cryptonote::gateway_owner_sig_v parse_gateway_owner_sig(
+        const cryptonote::gateway_owner_key_v& owner_key, std::string_view hex, std::string_view what)
+    {
+      if (!oxenc::is_hex(hex))
+        throw rpc_error{ERROR_WRONG_PARAM, std::string(what) + " is not valid hex"};
+      const std::string b = oxenc::from_hex(hex);
+      switch (owner_key.index())
+      {
+        case 0: { crypto::signature s{};       if (b.size() != sizeof(s)) throw rpc_error{ERROR_WRONG_PARAM, std::string(what) + ": Schnorr signature must be 64 bytes"}; std::memcpy(&s, b.data(), sizeof(s)); return s; }
+        case 1: { crypto::eth_signature s{};   if (b.size() != sizeof(s)) throw rpc_error{ERROR_WRONG_PARAM, std::string(what) + ": eth signature must be 64 bytes"};     std::memcpy(&s, b.data(), sizeof(s)); return s; }
+        case 2: { crypto::eddsa_signature s{}; if (b.size() != sizeof(s)) throw rpc_error{ERROR_WRONG_PARAM, std::string(what) + ": eddsa signature must be 64 bytes"};   std::memcpy(&s, b.data(), sizeof(s)); return s; }
+        default: throw rpc_error{ERROR_INTERNAL, "unknown gateway owner key type"};
+      }
+    }
+
+    // Parse a hex owner key of the named type into the variant.
+    cryptonote::gateway_owner_key_v parse_gateway_owner_key(std::string_view type, std::string_view hex)
+    {
+      if (type == "schnorr" || type == "ed25519")
+      {
+        crypto::public_key k{};
+        if (!tools::hex_to_type(hex, k))
+          throw rpc_error{ERROR_WRONG_PARAM, "invalid schnorr owner_key (expected 64-char hex)"};
+        return k;
+      }
+      if (type == "eth")
+      {
+        crypto::eth_public_key k{};
+        if (!tools::hex_to_type(hex, k))
+          throw rpc_error{ERROR_WRONG_PARAM, "invalid eth owner_key (expected 66-char hex / 33-byte compressed)"};
+        return k;
+      }
+      if (type == "eddsa")
+      {
+        crypto::eddsa_public_key k{};
+        if (!tools::hex_to_type(hex, k))
+          throw rpc_error{ERROR_WRONG_PARAM, "invalid eddsa owner_key (expected 64-char hex)"};
+        return k;
+      }
+      throw rpc_error{ERROR_WRONG_PARAM, "owner_key_type must be one of: schnorr, eth, eddsa"};
+    }
+  } // anonymous namespace
   void core_rpc_server::invoke(GATEWAY_SUBMIT_TRANSFER& cmd, rpc_context context)
   {
     auto& req = cmd.request;
@@ -3841,8 +3886,22 @@ namespace cryptonote::rpc {
     if (!cryptonote::parse_and_validate_tx_from_blob(blob, tx))
       throw rpc_error{ERROR_WRONG_PARAM, "failed to parse tx_blob"};
 
-    // If a detached owner signature was supplied, inject it (looking up the
-    // owner key type from the source gateway's on-chain descriptor).
+    // Which flow this is comes from the blob itself, not the caller: an update
+    // carries a descriptor op and needs a second signature over a different
+    // (domain-separated) message, a withdrawal needs only the input signature.
+    const bool is_update = tx.type == cryptonote::txtype::update_gateway_address;
+    const char* what     = is_update ? "gateway update" : "gateway withdrawal";
+
+    if (is_update && req.signature.empty() != req.ownership_signature.empty())
+      throw rpc_error{ERROR_WRONG_PARAM,
+          "an update_gateway_address tx needs both `signature` (over hash_to_sign_input) and "
+          "`ownership_signature` (over hash_to_sign_ownership), or neither for an already-signed blob"};
+    if (!is_update && !req.ownership_signature.empty())
+      throw rpc_error{ERROR_WRONG_PARAM,
+          "`ownership_signature` only applies to an update_gateway_address tx"};
+
+    // If detached owner signature(s) were supplied, inject them (looking up the
+    // owner key type from the gateway's on-chain descriptor).
     if (!req.signature.empty())
     {
       crypto::public_key source_id{};
@@ -3856,22 +3915,19 @@ namespace cryptonote::rpc {
       cryptonote::gateway_account_data acct;
       if (!cryptonote::load_gateway_account(db, source_id, acct) || acct.descriptor_history.empty())
         throw rpc_error{ERROR_WRONG_PARAM, "source gateway is not registered"};
+      // For an update this is deliberately the CURRENT owner key: the new key in
+      // the tx only takes effect once the tx is applied.
       const auto& okey = acct.latest_descriptor().owner_key;
 
-      if (!oxenc::is_hex(req.signature))
-        throw rpc_error{ERROR_WRONG_PARAM, "signature is not valid hex"};
-      const std::string sbytes = oxenc::from_hex(req.signature);
-
-      cryptonote::gateway_owner_sig_v osig;
-      switch (okey.index())
-      {
-        case 0: { crypto::signature s{};       if (sbytes.size() != sizeof(s)) throw rpc_error{ERROR_WRONG_PARAM, "Schnorr signature must be 64 bytes"};  std::memcpy(&s, sbytes.data(), sizeof(s)); osig = s; break; }
-        case 1: { crypto::eth_signature s{};   if (sbytes.size() != sizeof(s)) throw rpc_error{ERROR_WRONG_PARAM, "eth signature must be 64 bytes"};      std::memcpy(&s, sbytes.data(), sizeof(s)); osig = s; break; }
-        case 2: { crypto::eddsa_signature s{}; if (sbytes.size() != sizeof(s)) throw rpc_error{ERROR_WRONG_PARAM, "eddsa signature must be 64 bytes"};    std::memcpy(&s, sbytes.data(), sizeof(s)); osig = s; break; }
-        default: throw rpc_error{ERROR_INTERNAL, "unknown gateway owner key type"};
-      }
-      if (!cryptonote::finalize_gateway_withdraw_tx(m_core.get_nettype(), tx, okey, osig))
-        throw rpc_error{ERROR_WRONG_PARAM, "signature does not verify against the gateway owner key"};
+      const auto osig = parse_gateway_owner_sig(okey, req.signature, "signature");
+      const bool ok = is_update
+          ? cryptonote::finalize_gateway_update_tx(m_core.get_nettype(), tx, okey, osig,
+                parse_gateway_owner_sig(okey, req.ownership_signature, "ownership_signature"))
+          : cryptonote::finalize_gateway_withdraw_tx(m_core.get_nettype(), tx, okey, osig);
+      if (!ok)
+        throw rpc_error{ERROR_WRONG_PARAM,
+            is_update ? "signatures do not verify against the current gateway owner key"
+                      : "signature does not verify against the gateway owner key"};
     }
 
     std::string final_blob = tx_to_blob(tx);
@@ -3879,7 +3935,7 @@ namespace cryptonote::rpc {
     if (!m_core.handle_incoming_tx(final_blob, tvc, tx_pool_options::new_tx()) || tvc.m_verifivation_failed || !tvc.m_should_be_relayed)
     {
       std::string reason = print_tx_verification_context(tvc);
-      throw rpc_error{ERROR_INTERNAL, "gateway withdrawal rejected: " + reason};
+      throw rpc_error{ERROR_INTERNAL, std::string(what) + " rejected: " + reason};
     }
 
     NOTIFY_NEW_TRANSACTIONS::request r{};
@@ -3887,10 +3943,63 @@ namespace cryptonote::rpc {
     cryptonote_connection_context fake_context{};
     m_core.get_protocol()->relay_transactions(r, fake_context);
 
-    LOG_PRINT_L0("Gateway withdrawal transaction relayed: " << tools::type_to_hex(cryptonote::get_transaction_hash(tx)));
+    LOG_PRINT_L0("Gateway transaction relayed (" << what << "): " << tools::type_to_hex(cryptonote::get_transaction_hash(tx)));
     cmd.response["tx_hash"] = tools::type_to_hex(cryptonote::get_transaction_hash(tx));
     cmd.response["status"]  = STATUS_OK;
   }
+  //------------------------------------------------------------------------------------------------------------------------------
+
+  void core_rpc_server::invoke(GATEWAY_CREATE_UPDATE& cmd, rpc_context context)
+  {
+    auto& req = cmd.request;
+    const auto nettype = m_core.get_nettype();
+
+    cryptonote::gateway_address_parse_info info{};
+    if (!cryptonote::get_gateway_address_from_str(info, nettype, req.gateway_address))
+      throw rpc_error{ERROR_WRONG_PARAM, "invalid gateway_address (expected a gwB… address)"};
+    const crypto::public_key gateway_id = info.gateway_id;
+
+    auto& db = m_core.get_blockchain_storage().get_db();
+    cryptonote::gateway_account_data acct;
+    if (!cryptonote::load_gateway_account(db, gateway_id, acct) || acct.descriptor_history.empty())
+      throw rpc_error{ERROR_WRONG_PARAM, "gateway is not registered"};
+
+    if (req.fee == 0)
+      throw rpc_error{ERROR_WRONG_PARAM, "fee must be > 0 (it funds the update tx from the gateway balance)"};
+
+    uint64_t balance = 0;
+    for (const auto& b : acct.balances)
+      if (b.asset_id == crypto::null_aid) balance = b.amount;
+
+    const uint64_t total_fee = cryptonote::GATEWAY_ADDRESS_UPDATE_FEE + req.fee;
+    if (balance < total_fee)
+      throw rpc_error{ERROR_WRONG_PARAM, "insufficient gateway balance for update fee (requires 10 BDX update fee + miner fee)"};
+
+    const auto new_owner_key = parse_gateway_owner_key(req.owner_key_type, req.owner_key);
+
+    if (acct.latest_descriptor().owner_key == new_owner_key && acct.latest_descriptor().meta_info == req.meta_info)
+      throw rpc_error{ERROR_WRONG_PARAM, "new owner key and meta_info are identical to current descriptor (no-op update)"};
+
+    const auto hf_version = m_core.get_blockchain_storage().get_network_version();
+    cryptonote::transaction tx;
+    crypto::hash h_input{}, h_ownership{};
+    if (!cryptonote::construct_gateway_update_tx(hf_version, nettype, gateway_id, new_owner_key,
+                                                 req.meta_info, req.fee, tx, h_input, h_ownership))
+      throw rpc_error{ERROR_INTERNAL, "failed to construct gateway update transaction"};
+
+    // Both signatures verify against the CURRENT owner key; report it so the
+    // signer knows which key (and scheme) to use.
+    const auto& cur = acct.latest_descriptor().owner_key;
+    cmd.response["gateway_id"]             = tools::type_to_hex(gateway_id);
+    cmd.response["current_owner_key_type"] = cur.index();
+    cmd.response["current_owner_key"]      = std::visit([](const auto& k) { return tools::type_to_hex(k); }, cur);
+    cmd.response["unsigned_tx_blob"]       = oxenc::to_hex(tx_to_blob(tx));
+    cmd.response["hash_to_sign_input"]     = tools::type_to_hex(h_input);
+    cmd.response["hash_to_sign_ownership"] = tools::type_to_hex(h_ownership);
+    cmd.response["fee"]                    = req.fee;
+    cmd.response["status"]                 = STATUS_OK;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
 
   //------------------------------------------------------------------------------------------------------------------------------
   void core_rpc_server::invoke(BNS_RESOLVE& resolve, rpc_context context)

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -199,6 +199,7 @@ namespace cryptonote::rpc {
     void invoke(GET_GATEWAY_HISTORY& get_gateway_history, rpc_context context);
     void invoke(GATEWAY_CREATE_TRANSFER& gateway_create_transfer, rpc_context context);
     void invoke(GATEWAY_SUBMIT_TRANSFER& gateway_submit_transfer, rpc_context context);
+    void invoke(GATEWAY_CREATE_UPDATE& gateway_create_update, rpc_context context);
     void invoke(BNS_RESOLVE& resolve, rpc_context context);
     void invoke(BNS_LOOKUP& lookup, rpc_context context);
     void invoke(BNS_VALUE_DECRYPT& value_decrypt, rpc_context context);

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -408,8 +408,18 @@ namespace cryptonote::rpc {
 
   void parse_request(GATEWAY_SUBMIT_TRANSFER& c, rpc_input in) {
     get_values(in,
-        "signature", c.request.signature,
-        "tx_blob",   required{c.request.tx_blob});
+        "ownership_signature", c.request.ownership_signature,
+        "signature",           c.request.signature,
+        "tx_blob",             required{c.request.tx_blob});
+  }
+
+  void parse_request(GATEWAY_CREATE_UPDATE& c, rpc_input in) {
+    get_values(in,
+        "fee",             required{c.request.fee},
+        "gateway_address", required{c.request.gateway_address},
+        "meta_info",       c.request.meta_info,
+        "owner_key",       required{c.request.owner_key},
+        "owner_key_type",  required{c.request.owner_key_type});
   }
 
   void parse_request(BNS_RESOLVE& resolve, rpc_input in) {

--- a/src/rpc/core_rpc_server_command_parser.h
+++ b/src/rpc/core_rpc_server_command_parser.h
@@ -48,6 +48,7 @@ namespace cryptonote::rpc {
   void parse_request(GET_GATEWAY_HISTORY& get_gateway_history, rpc_input in);
   void parse_request(GATEWAY_CREATE_TRANSFER& c, rpc_input in);
   void parse_request(GATEWAY_SUBMIT_TRANSFER& c, rpc_input in);
+  void parse_request(GATEWAY_CREATE_UPDATE& c, rpc_input in);
   void parse_request(OUT_PEERS& out_peers, rpc_input in);
   void parse_request(GET_OUTPUT_DISTRIBUTION& get_output_distribution, rpc_input in);
   void parse_request(POP_BLOCKS& pop_blocks, rpc_input in);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2791,17 +2791,23 @@ namespace cryptonote::rpc {
 
   /// RPC: gateway/gateway_submit_transfer
   ///
-  /// Admin-only. Attaches the gateway owner signature to an unsigned withdrawal
-  /// from `gateway_create_transfer` and broadcasts it. The owner key type is
-  /// looked up from the source gateway's on-chain descriptor, so the signature is
-  /// parsed to match. Alternatively an already-signed blob (proofs embedded) can
-  /// be submitted with an empty `signature`.
+  /// Admin-only. Attaches the gateway owner signature(s) to any unsigned gateway
+  /// tx — a withdrawal from `gateway_create_transfer` or a descriptor update from
+  /// `gateway_create_update` — and broadcasts it. Which flow applies is taken from
+  /// the blob's own tx type, not from the caller, so the same endpoint serves both.
+  /// The owner key type is looked up from the gateway's on-chain descriptor, so
+  /// the signature(s) are parsed to match. Alternatively an already-signed blob
+  /// (proofs embedded) can be submitted with the signature fields empty.
   ///
   /// Inputs:
-  /// - `tx_blob` -- hex of the (unsigned) tx from `gateway_create_transfer`.
-  /// - `signature` -- hex of the owner signature over `hash_to_sign`
-  ///   (Schnorr = 128 hex, eth/eddsa sized to their scheme). Omit to submit a
-  ///   blob that already carries its gateway proofs.
+  /// - `tx_blob` -- hex of the (unsigned) tx from `gateway_create_transfer` or
+  ///   `gateway_create_update`.
+  /// - `signature` -- hex of the owner signature over `hash_to_sign` (withdrawal)
+  ///   or `hash_to_sign_input` (update). Schnorr = 128 hex, eth/eddsa sized to
+  ///   their scheme. Omit to submit a blob that already carries its gateway proofs.
+  /// - `ownership_signature` -- UPDATE ONLY, and required there: hex of the
+  ///   signature over `hash_to_sign_ownership`. Both signatures come from the
+  ///   CURRENT owner key. Ignored for withdrawals.
   ///
   /// Output:
   /// - `tx_hash` -- hex of the broadcast transaction.
@@ -2813,8 +2819,54 @@ namespace cryptonote::rpc {
     {
       std::string tx_blob;
       std::string signature;
+      std::string ownership_signature; // update_gateway_address txs only
     } request;
   };
+
+  /// RPC: gateway/gateway_create_update
+  ///
+  /// Admin-only. Builds an UNSIGNED gateway descriptor update (HF22): replaces the
+  /// gateway's owner key and/or meta_info. The tx is self-funded — a single
+  /// txin_gateway spends `fee` from the gateway's own balance and there are no
+  /// outputs — so the node needs no wallet and no keys.
+  ///
+  /// Unlike a withdrawal this needs TWO signatures, both from the CURRENT owner
+  /// key (the new key only takes effect once the tx is applied), over separate
+  /// domain-separated messages: one authorizing the fee spend and one authorizing
+  /// the descriptor change. Sign both, then broadcast via `gateway_submit_transfer`
+  /// (`signature` = hash_to_sign_input, `ownership_signature` = hash_to_sign_ownership).
+  ///
+  /// The node NEVER handles an owner secret: it only ever returns an UNSIGNED tx.
+  ///
+  /// Inputs:
+  /// - `gateway_address` -- the gateway to update (gwB… address).
+  /// - `owner_key_type` -- new owner key type: "schnorr" (native), "eth" (secp256k1), or "eddsa".
+  /// - `owner_key` -- hex of the new owner key (64 for schnorr/eddsa, 66 for eth-compressed).
+  /// - `meta_info` -- (Optional) new descriptor meta string (max 255 bytes).
+  /// - `fee` -- fee to spend from the gateway's balance (must be > 0).
+  ///
+  /// Output:
+  /// - `gateway_id` -- hex of the resolved gateway id.
+  /// - `current_owner_key_type` -- the key type that must produce BOTH signatures.
+  /// - `current_owner_key` -- hex of the current owner key (what the signatures verify against).
+  /// - `unsigned_tx_blob` -- hex of the unsigned tx to sign + submit.
+  /// - `hash_to_sign_input` -- 64-char hex; authorizes spending the fee.
+  /// - `hash_to_sign_ownership` -- 64-char hex; authorizes the descriptor change.
+  /// - `fee` -- the fee.
+  /// - `status` -- Generic RPC error code. "OK" is the success value.
+  struct GATEWAY_CREATE_UPDATE : RPC_COMMAND
+  {
+    static constexpr auto names() { return NAMES("gateway_create_update"); }
+    struct request_parameters
+    {
+      std::string gateway_address;
+      std::string owner_key_type;
+      std::string owner_key;
+      std::string meta_info;
+      uint64_t fee = 0;
+    } request;
+  };
+
 
   // List of all supported rpc command structs to allow compile-time enumeration of all supported
   // RPC types.  Every type added above that has an RPC endpoint needs to be added here, and needs
@@ -2827,6 +2879,7 @@ namespace cryptonote::rpc {
     GET_GATEWAY_HISTORY,
     GATEWAY_CREATE_TRANSFER,
     GATEWAY_SUBMIT_TRANSFER,
+    GATEWAY_CREATE_UPDATE,
     BANNED,
     FLUSH_CACHE,
     FLUSH_TRANSACTION_POOL,


### PR DESCRIPTION
Finalize gateway ownership update functionality with dual-signature authorization.

Key changes:
- Cryptographic Authorization: Implement dual-signature verification using domain-separated hashes (GW_INPUT_SIG & GW_OWNERSHIP) to authorize input fee spending and descriptor modification independently.
- Canonical Proof Structure: Store proofs in canonical order [ownership_proof][input_sig] inside tx.gateway_proofs.
- Update Fee Integration: Define GATEWAY_ADDRESS_UPDATE_FEE, burn update fee via tx_extra_burn, and enforce total debit (burn fee + miner fee) from source gateway balance.
- No-Op Protection: Add checks in RPC (gateway_create_update) and consensus (validate_gateway_descriptor_operation) to reject updates when owner key and meta_info are unchanged.