### PR TITLE
Enforce collateral amount validation for private token registration

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -992,6 +992,19 @@ namespace cryptonote
     return result;
   }
   //---------------------------------------------------------------
+  bool get_collateral_lock_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_collateral_lock& lock)
+  {
+    return get_field_from_tx_extra(tx_extra, lock);
+  }
+  //---------------------------------------------------------------
+  bool add_collateral_lock_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_collateral_lock& lock)
+  {
+    tx_extra_field field = lock;
+    bool result = add_tx_extra_field_to_tx_extra(tx_extra, field);
+    CHECK_AND_NO_ASSERT_MES_L1(result, false, "failed to serialize tx extra collateral lock");
+    return result;
+  }
+  //---------------------------------------------------------------
   bool add_token_descriptor_operation_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_token_descriptor_operation& op)
   {
     tx_extra_field field = op;

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -170,6 +170,8 @@ namespace cryptonote
   bool get_encrypted_payment_id_from_tx_extra_nonce(const blobdata& extra_nonce, crypto::hash8& payment_id);
   bool add_burned_amount_to_tx_extra(std::vector<uint8_t>& tx_extra, uint64_t burn);
   uint64_t get_burned_amount_from_tx_extra(const std::vector<uint8_t>& tx_extra);
+  bool get_collateral_lock_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_collateral_lock& lock);
+  bool add_collateral_lock_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_collateral_lock& lock);
   bool add_token_descriptor_operation_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_token_descriptor_operation& op);
   bool get_token_descriptor_operation_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_token_descriptor_operation& op, size_t skip = 0);
   bool is_out_to_acc(const account_keys& acc, const txout_to_key& out_key, const crypto::public_key& tx_pub_key, const std::vector<crypto::public_key>& additional_tx_public_keys, size_t output_index);

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -65,6 +65,7 @@ constexpr uint8_t
   TX_EXTRA_TAG_BELDEX_NAME_SYSTEM           = 0x7A,
   TX_EXTRA_TAG_TOKEN_DESCRIPTOR_OPERATION = 0x7B,
   TX_EXTRA_TAG_SECURITY_SIGNATURE          = 0x88,
+  TX_EXTRA_TAG_COLLATERAL_LOCK            = 0x89,
   TX_EXTRA_MYSTERIOUS_MINERGATE_TAG       = 0xDE;
 
 constexpr char
@@ -546,6 +547,28 @@ namespace cryptonote
     END_SERIALIZE()
   };
 
+  // Opens the collateral output's amount commitment to consensus.
+  //
+  // Output amounts are hidden inside Pedersen commitments (amount*H + mask*G),
+  // so a validator cannot otherwise tell a 10,000 BDX collateral lock apart from
+  // a 1 atomic unit one. Publishing the amount together with that output's
+  // blinding mask lets the validator recompute the commitment and compare it
+  // against the one on chain, which a false amount cannot match. Only this one
+  // output is revealed: the mask is a hash of that output's own shared secret,
+  // so it discloses neither the tx secret key nor any other output.
+  struct tx_extra_collateral_lock
+  {
+    uint64_t amount;       // Declared collateral amount (must be >= REGISTRATION_COLLATERAL_AMOUNT)
+    rct::key mask;         // Blinding factor of that output's amount commitment
+    uint8_t  output_index; // Index into tx.vout[] of the collateral output
+
+    BEGIN_SERIALIZE()
+      FIELD(amount)
+      FIELD(mask)
+      FIELD(output_index)
+    END_SERIALIZE()
+  };
+
   // Initial protocol-layer scaffold for Zano-style custom tokens.
   // This introduces the wire representation in tx.extra; construction and
   // consensus rules will be added in follow-up changes.
@@ -721,7 +744,8 @@ namespace cryptonote
       tx_extra_merge_mining_tag,
       tx_extra_mysterious_minergate,
       tx_extra_padding,
-      tx_extra_security_signature
+      tx_extra_security_signature,
+      tx_extra_collateral_lock
       >;
 }
 
@@ -747,3 +771,4 @@ BINARY_VARIANT_TAG(cryptonote::tx_extra_burn,                        cryptonote:
 BINARY_VARIANT_TAG(cryptonote::tx_extra_token_descriptor_operation,  cryptonote::TX_EXTRA_TAG_TOKEN_DESCRIPTOR_OPERATION);
 BINARY_VARIANT_TAG(cryptonote::tx_extra_beldex_name_system,            cryptonote::TX_EXTRA_TAG_BELDEX_NAME_SYSTEM);
 BINARY_VARIANT_TAG(cryptonote::tx_extra_security_signature,            cryptonote::TX_EXTRA_TAG_SECURITY_SIGNATURE);
+BINARY_VARIANT_TAG(cryptonote::tx_extra_collateral_lock,               cryptonote::TX_EXTRA_TAG_COLLATERAL_LOCK);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3950,12 +3950,44 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       if (tx.type == txtype::register_private_token)
       {
         const uint64_t min_collateral_unlock_height = get_current_blockchain_height() + tokens::REGISTRATION_COLLATERAL_LOCK_BLOCKS;
+
+        cryptonote::tx_extra_collateral_lock coll_lock;
+        if (!cryptonote::get_collateral_lock_from_tx_extra(tx.extra, coll_lock))
+        {
+          tvc.m_verbose_error = "Token registration missing tx_extra_collateral_lock";
+          MERROR_VER("Failed to validate Token TX reason: " << tvc.m_verbose_error);
+          return false;
+        }
+
+        if (coll_lock.amount < tokens::REGISTRATION_COLLATERAL_AMOUNT)
+        {
+          tvc.m_verbose_error = "Token registration collateral " + std::to_string(coll_lock.amount) +
+                                " is below minimum " + std::to_string(tokens::REGISTRATION_COLLATERAL_AMOUNT);
+          MERROR_VER("Failed to validate Token TX reason: " << tvc.m_verbose_error);
+          return false;
+        }
+
+        // Recompute the commitment the declared amount and mask imply. A declared
+        // amount the output does not actually hold cannot reproduce the
+        // commitment that is on chain, so this is what binds the two.
+        const rct::key expected_commitment = rct::commit(coll_lock.amount, coll_lock.mask);
         bool has_locked_native_collateral_output = false;
 
+        // tx_out_zarcanum outputs carry their own commitments and are skipped when
+        // the native RingCT vectors are built, so outPk is indexed by the native
+        // outputs alone -- not by tx.vout index.
+        size_t rct_index = 0;
         for (size_t out_index = 0; out_index < tx.vout.size(); ++out_index)
         {
-          if (std::holds_alternative<txout_to_key>(tx.vout[out_index].target) &&
-              tx.get_unlock_time(out_index) >= min_collateral_unlock_height)
+          if (!std::holds_alternative<txout_to_key>(tx.vout[out_index].target))
+            continue;
+
+          const size_t out_rct_index = rct_index++;
+          if (tx.get_unlock_time(out_index) < min_collateral_unlock_height)
+            continue;
+
+          if (out_rct_index < tx.rct_signatures.outPk.size() &&
+              tx.rct_signatures.outPk[out_rct_index].mask == expected_commitment)
           {
             has_locked_native_collateral_output = true;
             break;
@@ -3964,7 +3996,9 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
 
         if (!has_locked_native_collateral_output)
         {
-          tvc.m_verbose_error = "Token registration requires a locked native collateral output for " +
+          tvc.m_verbose_error = "Token registration requires a locked collateral output of at least " +
+                                std::to_string(tokens::REGISTRATION_COLLATERAL_AMOUNT) +
+                                " whose commitment matches the declared amount, locked for " +
                                 std::to_string(tokens::REGISTRATION_COLLATERAL_LOCK_BLOCKS) + " blocks";
           MERROR_VER("Failed to validate Token TX reason: " << tvc.m_verbose_error);
           return false;

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1411,6 +1411,44 @@ namespace cryptonote
               }
           }
 
+          // ── HF21: open the registration collateral output to consensus ──────
+          // A register_private_token tx locks a native collateral output instead
+          // of burning anything, but its amount is hidden in a Pedersen
+          // commitment that a validator cannot open. Publish the amount together
+          // with that output's blinding mask so the daemon can recompute the
+          // commitment and check it. The collateral is the sole native output
+          // carrying a non-zero unlock time (change and ordinary outputs are
+          // unlocked). This has to run here: the mask depends on amount_keys,
+          // which only exist after the output loop above, and tx.extra must be
+          // final before the prefix hash below is signed.
+          if (tx.type == txtype::register_private_token)
+          {
+              size_t collateral_index = tx.vout.size();
+              for (size_t i = 0; i < tx.vout.size(); ++i)
+              {
+                  if (!std::holds_alternative<txout_to_key>(tx.vout[i].target) || tx.get_unlock_time(i) == 0)
+                      continue;
+                  CHECK_AND_ASSERT_MES(collateral_index == tx.vout.size(), false,
+                      "register_private_token tx must have exactly one locked native collateral output");
+                  collateral_index = i;
+              }
+              CHECK_AND_ASSERT_MES(collateral_index < tx.vout.size(), false,
+                  "register_private_token tx is missing its locked native collateral output");
+              CHECK_AND_ASSERT_MES(collateral_index < amount_keys.size(), false,
+                  "Missing amount key for the collateral output");
+
+              tx_extra_collateral_lock collateral_lock{};
+              collateral_lock.amount       = tx.vout[collateral_index].amount; // still plaintext, zeroed just below
+              collateral_lock.mask         = rct::genCommitmentMask(amount_keys[collateral_index]);
+              collateral_lock.output_index = static_cast<uint8_t>(collateral_index);
+
+              remove_field_from_tx_extra<tx_extra_collateral_lock>(tx.extra);
+              if (!add_collateral_lock_to_tx_extra(tx.extra, collateral_lock)) {
+                  LOG_ERROR("failed to add collateral lock to tx extra");
+                  return false;
+              }
+          }
+
           // zero out all amounts to mask rct outputs, real amounts are now encrypted
           for (size_t i = 0; i < tx.vin.size(); ++i) {
               if (sources[i].rct && !sources[i].is_zarcanum())

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -76,6 +76,7 @@ struct extra_printer {
   void operator()(const tx_extra_tx_key_image_proofs& x) { std::cout << "TX key image proofs (" << x.proofs.size() << ")"; }
   void operator()(const tx_extra_tx_key_image_unlock& x) { std::cout << "TX key image unlock: " << x.key_image; }
   void operator()(const tx_extra_burn& x) { std::cout << "Transaction burned fee/payment: " << print_money(x.amount); }
+  void operator()(const tx_extra_collateral_lock& x) { std::cout << "Collateral lock: " << print_money(x.amount) << " at output " << (unsigned)x.output_index; }
   void operator()(const tx_extra_beldex_name_system& x) {
     std::cout << "BNS " << (x.is_buying() ? "registration" : x.is_updating() ? "update" : "(unknown)");
     switch (x.type)

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -706,6 +706,7 @@ namespace cryptonote::rpc {
       void operator()(const tx_extra_merge_mining_tag& x) { set("mm_depth", x.depth); set("mm_root", x.merkle_root); }
       void operator()(const tx_extra_additional_pub_keys& x) { set("additional_pubkeys", x.data); }
       void operator()(const tx_extra_burn& x) { set("burn_amount", x.amount); }
+      void operator()(const tx_extra_collateral_lock& x) { set("collateral_amount", x.amount); set("collateral_output_index", x.output_index); }
       static const char* token_op_type_name(token_descriptor_operation_type type) {
         switch (type)
         {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11790,6 +11790,10 @@ std::vector<wallet2::pending_tx> wallet2::create_private_token_registration_tx(
   beldex_construct_tx_params tx_params = wallet2::construct_params(
       *hf_ver, txtype::register_private_token, priority);
 
+  // NOTE: the tx_extra collateral lock is written during tx construction
+  // (construct_tx_with_tx_key), which is the first point where the collateral
+  // output's blinding mask exists and the last point where tx.extra can still
+  // change before the prefix hash is signed.
   return create_transactions_2(dsts, fake_outs_count, 0 /*unlock_time*/,
                                priority, extra, subaddr_account,
                                subaddr_indices, tx_params);


### PR DESCRIPTION
Add tx_extra_collateral_lock metadata to serialize declared collateral amounts in tx.extra for private token registration transactions. Update wallet2 to attach collateral metadata during tx construction and enforce consensus-level verification in Blockchain::check_tx_inputs to validate that the collateral amount meets REGISTRATION_COLLATERAL_AMOUNT.

- Introduce TX_EXTRA_TAG_COLLATERAL_LOCK (0x89) and tx_extra_collateral_lock struct
- Add serialization and extraction helpers in cryptonote_format_utils
- Attach collateral lock metadata in wallet2::create_private_token_registration_tx
- Enforce minimum collateral amount check in Blockchain::check_tx_inputs